### PR TITLE
adding new frontend query logging to capture search querystrings

### DIFF
--- a/app/models/shared/QueryLogConfig.scala
+++ b/app/models/shared/QueryLogConfig.scala
@@ -10,6 +10,7 @@ object QueryLogConfig extends Configurable {
   def enabled = getBoolean("enabled", false)
   def includeResults = getBoolean("includeResults", false)
   def prefix = getString("prefix", "")
+  def frontendLogging = getBoolean("frontendLogging", false)
 
   override protected def validateConfig() {
     if (enabled) {

--- a/conf/dev_base.conf
+++ b/conf/dev_base.conf
@@ -166,9 +166,10 @@ cache {
 # Set logging properties in logger.xml or dev_logger.xml
 
 querylog {
-  enabled = true
+  enabled = false
   prefix = "QUERY: "
   includeResults = false
+  frontendLogging = true
 }
 
 solr {

--- a/conf/reference/querylog_reference.conf
+++ b/conf/reference/querylog_reference.conf
@@ -6,4 +6,6 @@ querylog {
 
   prefix = "QUERY: "
 
+  frontendLogging = false
+
 }


### PR DESCRIPTION
This will allow us capture asset find requests to write tests to verify solr searches match mysql searches.

I've also switched off the mysql query logging since we don't need it now.
