### PR TITLE
using sonatype repo for snakeyaml dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ scalacOptions ++= Seq("-deprecation","-unchecked")
 
 resolvers += "Twitter Repository" at "http://maven.twttr.com/"
 
+resolvers += "Sonatype-public" at "http://oss.sonatype.org/content/groups/public"
+
 parallelExecution in Test := false
 
 parallelExecution in IntegrationTest := false
@@ -25,7 +27,7 @@ libraryDependencies ++= Seq(
   "com.twitter" %% "finagle-http" % "1.10.0",
   "org.jsoup" % "jsoup" % "1.6.1",
   "org.squeryl" %% "squeryl" % "0.9.5",
-  "org.yaml" % "snakeyaml" % "1.11-SNAPSHOT" from ("file://" + file(".") + "lib/snakeyaml-1.11-SNAPSHOT.jar")
+  "org.yaml" % "snakeyaml" % "1.11-SNAPSHOT" 
 )
 
 


### PR DESCRIPTION
On my macbook, sbt was resolving the wrong folder for fetching the snakeyaml jar.  I switched it here to use the publicly available one instead.  Not sure if there was a specific reason for using the bundled jar, but this let me compile and all tests pass.
