### PR TITLE
Include exception message on ldap auth failures to ease debugging

### DIFF
--- a/app/util/security/LdapAuthenticationProvider.scala
+++ b/app/util/security/LdapAuthenticationProvider.scala
@@ -69,7 +69,7 @@ class LdapAuthenticationProvider() extends AuthenticationProvider {
       Some(user)
     } catch {
       case e: AuthenticationException =>
-        logger.info("Failed authentication for user %s".format(username))
+        logger.info("Failed authentication for user %s with error %s".format(username, e.getMessage))
         None
       case e: Throwable =>
         logger.info("Failed authentication", e)


### PR DESCRIPTION
Something along the lines of "[LDAP: error code 49 - Invalid
Credentials]", and as far as I know should not include credentials
