### PR TITLE
Metrics reporter config

### DIFF
--- a/app/util/plugins/MetricsReporterConfig.scala
+++ b/app/util/plugins/MetricsReporterConfig.scala
@@ -1,0 +1,21 @@
+package util.plugins
+
+import collins.validation.File
+import util.config.Configurable
+import util.config.ConfigValue
+
+
+object MetricsReporterConfig extends Configurable {
+
+  override val namespace = "metricsreporter"
+  override val referenceConfigFilename = "metricsreporter_reference.conf"
+
+  def enabled = getBoolean("enabled", false)
+  def configFile = getString("configFile")(ConfigValue.Required).get
+
+  override def validateConfig() {
+    enabled
+    File.requireFileIsReadable(configFile)
+  }
+
+}

--- a/app/util/plugins/MetricsReporterPlugin.scala
+++ b/app/util/plugins/MetricsReporterPlugin.scala
@@ -1,0 +1,28 @@
+package util.plugins
+
+import play.api.{Application, Logger, Play, Plugin}
+
+import com.addthis.metrics.reporter.config.ReporterConfig
+
+class MetricsReporterPlugin(app: Application) extends Plugin
+{
+
+  override def enabled: Boolean = {
+    MetricsReporterConfig.pluginInitialize(app.configuration)
+    MetricsReporterConfig.enabled
+  }
+
+  override def onStart() {
+    MetricsReporterConfig.validateConfig()
+    try {
+      Logger.info("Trying to load metrics-reporter-config...")
+      ReporterConfig.loadFromFileAndValidate(MetricsReporterConfig.configFile).enableAll()
+    }
+    catch {
+      case e: Exception => Logger.warn("Failed to load metrics-reporter-config", e)
+    }
+  }
+
+  override def onStop() {
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ libraryDependencies ++= Seq(
   "org.mockito" % "mockito-all" % "1.9.0" % "test",
   "com.google.guava" % "guava" % "11.0.2",
   "com.yammer.metrics" %% "metrics-scala" % "2.2.0",
+  "com.addthis.metrics" % "reporter-config" % "2.0.5",
   "mysql" % "mysql-connector-java" % "5.1.19",
   "com.h2database" % "h2" % "1.3.158",
   "org.apache.solr" % "solr-solrj" % "3.6.1",

--- a/conf/play.plugins
+++ b/conf/play.plugins
@@ -1,6 +1,7 @@
 3800:collins.logging.LoggingPlugin
 3900:collins.database.DatabasePlugin
 4000:collins.config.ConfigPlugin
+4010:util.plugins.MetricsReporterPlugin
 4100:collins.cache.CachePlugin
 4200:collins.callbacks.CallbackManagerPlugin
 4300:collins.solr.SolrPlugin

--- a/conf/reference/metricsreporter_reference.conf
+++ b/conf/reference/metricsreporter_reference.conf
@@ -1,0 +1,5 @@
+metricsreporter {
+  enabled = false
+  configFile = "conf/metrics-reporter-config.yaml"
+}
+


### PR DESCRIPTION
Example config:

```
metricsreporter {
  enabled = true
  configFile = "conf/metrics-reporter-config.yaml"
}
```

```
$ cat conf/metrics-reporter-config.yaml
ganglia:
  -
    period: 30
    timeunit: 'SECONDS'
    groupPrefix: 'collins'
    gmondConf: '/etc/ganglia/gmond.conf'
```
