### PR TITLE
If we have a dropdown in the UI, do an exact search

### DIFF
--- a/app/views/resources/optionDisplay.scala.html
+++ b/app/views/resources/optionDisplay.scala.html
@@ -4,7 +4,7 @@
 @import _root_.models.lshw.Disk
 
 @formatValue(value: String, display: String) = {
-<option value="@value">@display</option>
+<option value="^@value$">@display</option>
 }
 <select name="@assetMeta.name" id="@assetMeta.name" tabindex="@(index + 2)" @if(index == 0) {accesskey="r"}>
   <option value="" selected="selected"></option>


### PR DESCRIPTION
Theoretically the previous behavior would not work if one value was a
substring of the other.  In practice it also would fail to find any
results for some odd combination of edge cases, for example "Dell
Inc."

should handle #78
