### PR TITLE
Default nic card to configured speed when missing in lshw

### DIFF
--- a/app/util/config/LshwConfig.scala
+++ b/app/util/config/LshwConfig.scala
@@ -9,11 +9,13 @@ object LshwConfig extends Configurable {
   def flashSize = getLong("flashSize", 1400000000000L)
   def includeDisabledCpu = getBoolean("includeDisabledCpu", false)
   def includeEmptySocket = getBoolean("includeEmptySocket", false)
+  def defaultNicCapacity = getString("defaultNicCapacity")(ConfigValue.Optional)
 
   override protected def validateConfig() {
     flashProduct
     flashSize
     includeDisabledCpu
     includeEmptySocket
+    defaultNicCapacity
   }
 }

--- a/conf/dev_base.conf
+++ b/conf/dev_base.conf
@@ -201,6 +201,10 @@ ipmi {
 lshw {
   flashProduct="flashmax"
   flashSize="1400000000000"
+
+  # For assets whose NIC capacity cannot be determined
+  # Omit this default to instead raise an exception when capacity missing
+  lshw.defaultNicCapacity=10000000000
 }
 
 include "authentication.conf"

--- a/test/resources/lshw-quad.xml
+++ b/test/resources/lshw-quad.xml
@@ -539,7 +539,6 @@
              <version>01</version>
              <serial>90:e2:ba:09:e2:a0</serial>
              <size units="bit/s">1000000000</size>
-             <capacity>1000000000</capacity>
              <width units="bits">32</width>
              <clock units="Hz">33000000</clock>
              <configuration>

--- a/test/util/parsers/LshwParserSpec.scala
+++ b/test/util/parsers/LshwParserSpec.scala
@@ -80,7 +80,7 @@ class LshwParserSpec extends mutable.Specification {
       } // basic
 
       "quad nic" in new LshwParserHelper("lshw-quad.xml") {
-        val parseResults = parsed()
+        val parseResults = parsed(Map("defaultNicCapacity" -> "10000000000"))
         parseResults must beRight
         parseResults.right.toOption must beSome.which { rep =>
           rep.cpuCount mustEqual 2
@@ -102,7 +102,7 @@ class LshwParserSpec extends mutable.Specification {
 
           rep.nicCount mustEqual 6
           rep.hasGbNic must beTrue
-          rep.has10GbNic must beFalse
+          rep.has10GbNic aka "has 10 gig card" must beTrue // picked up from default in config
           rep.macAddresses must have length 6
           rep.macAddresses must beNonEmptyStringSeq
         }


### PR DESCRIPTION
Some of our machines aren't including the NIC capacity in their lshw output =(

Rather than fail the intake process, we're comfortable assigning a default speed and updating it later.
