### PR TITLE
optionally make vlan name optional

### DIFF
--- a/app/util/config/LldpConfig.scala
+++ b/app/util/config/LldpConfig.scala
@@ -1,0 +1,13 @@
+package util
+package config
+
+object LldpConfig extends Configurable {
+  override val namespace = "lldp"
+  override val referenceConfigFilename = "lldp_reference.conf"
+
+  def requireVlanName = getBoolean("requireVlanName", true)
+
+  override protected def validateConfig() {
+    requireVlanName
+  }
+}

--- a/app/util/parsers/LldpParser.scala
+++ b/app/util/parsers/LldpParser.scala
@@ -2,6 +2,7 @@ package util
 package parsers
 
 import models.lldp._
+import config.LldpConfig
 import scala.xml.{Elem, MalformedAttributeException, Node, NodeSeq, XML}
 
 class LldpParser(txt: String) extends CommonParser[LldpRepresentation](txt) {
@@ -61,7 +62,11 @@ class LldpParser(txt: String) extends CommonParser[LldpRepresentation](txt) {
     (seq \\ "vlan").foldLeft(Seq[Vlan]()) { case(vseq, vlan) =>
       val id = Option(vlan \ "@vlan-id" text).filter(_.nonEmpty).getOrElse("0")
       val name = vlan.text
-      requireNonEmpty((id -> "vlan-id"), (name -> "vlan name"))
+      if (LldpConfig.requireVlanName) {
+        requireNonEmpty((id -> "vlan-id"), (name -> "vlan name"))
+      } else {
+        requireNonEmpty((id -> "vlan-id"))
+      }
       Vlan(id.toInt, name) +: vseq
     }
   }

--- a/conf/reference/lldp_reference.conf
+++ b/conf/reference/lldp_reference.conf
@@ -1,0 +1,5 @@
+lldp {
+     # Refuse to accept lldp information with no name (aka
+     # description)
+     requireVlanName = true
+}

--- a/conf/validations.conf
+++ b/conf/validations.conf
@@ -13,6 +13,7 @@ config.validations = [
   util.config.Feature,
   util.config.IpmiConfig,
   util.config.LshwConfig,
+  util.config.LldpConfig,
   util.config.MultiCollinsConfig,
   util.config.NodeclassifierConfig,
   util.power.PowerConfiguration,

--- a/test/resources/lldpctl-no-name.xml
+++ b/test/resources/lldpctl-no-name.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lldp label="LLDP neighbors">
+ <interface label="Interface" name="eth0" via="LLDP" rid="1" age="0 day, 00:00:44">
+  <chassis label="Chassis">
+   <id label="ChassisID" type="mac">00:00:00:00:00:00</id>
+   <name label="SysName">laxb-101</name>
+   <descr label="SysDescr">HP Switch </descr>
+   <capability label="Capability" type="Bridge" enabled="on"/>
+   <capability label="Capability" type="Router" enabled="off"/>
+  </chassis>
+  <port label="Port">
+   <id label="PortID" type="local">9</id>
+   <descr label="PortDescr">A9</descr>
+   <auto-negotiation label="PMD autoneg" supported="yes" enabled="yes">
+    <advertised label="Adv" type="10Base-T" hd="yes" fd="yes"/>
+    <advertised label="Adv" type="100Base-TX" hd="yes" fd="yes"/>
+    <advertised label="Adv" type="1000Base-T" hd="no" fd="yes"/>
+    <current label="MAU oper type">1000BaseTFD - Four-pair Category 5 UTP, full duplex mode</current>
+   </auto-negotiation>
+   <power label="MDI Power" supported="yes" enabled="yes" paircontrol="no">
+    <device-type label="Device type">PSE</device-type>
+    <pairs label="Power pairs">signal</pairs>
+    <class label="Class">class 0</class>
+   </power>
+  </port>
+  <vlan label="VLAN" vlan-id="100" pvid="yes"/>
+ </interface>
+ <interface label="Interface" name="eth1" via="LLDP" rid="1" age="0 day, 00:00:44">
+  <chassis label="Chassis">
+   <id label="ChassisID" type="mac">00:00:00:00:00:00</id>
+   <name label="SysName">laxb-101</name>
+   <descr label="SysDescr">HP Switch</descr>
+   <capability label="Capability" type="Bridge" enabled="on"/>
+   <capability label="Capability" type="Router" enabled="off"/>
+  </chassis>
+  <port label="Port">
+   <id label="PortID" type="local">65</id>
+   <descr label="PortDescr">C17</descr>
+   <auto-negotiation label="PMD autoneg" supported="yes" enabled="yes">
+    <advertised label="Adv" type="10Base-T" hd="yes" fd="yes"/>
+    <advertised label="Adv" type="100Base-TX" hd="yes" fd="yes"/>
+    <advertised label="Adv" type="1000Base-T" hd="no" fd="yes"/>
+    <current label="MAU oper type">1000BaseTFD - Four-pair Category 5 UTP, full duplex mode</current>
+   </auto-negotiation>
+   <power label="MDI Power" supported="yes" enabled="yes" paircontrol="no">
+    <device-type label="Device type">PSE</device-type>
+    <pairs label="Power pairs">signal</pairs>
+    <class label="Class">class 0</class>
+   </power>
+  </port>
+  <vlan label="VLAN" vlan-id="101" pvid="yes"/>
+ </interface>
+</lldp>

--- a/test/util/parsers/CommonParserSpec.scala
+++ b/test/util/parsers/CommonParserSpec.scala
@@ -3,6 +3,7 @@ package util
 package parsers
 
 import play.api.Configuration
+import _root_.util.config.LldpConfig
 import _root_.util.config.LshwConfig
 import org.specs2._
 import specification._
@@ -19,6 +20,7 @@ trait CommonParserSpec[REP] extends ResourceFinder {
       _root_.util.config.AppConfig.globalConfig = None;
     }
     LshwConfig.initialize
+    LldpConfig.initialize
     val parser = getParser(data)
     parser.parse()
   }


### PR DESCRIPTION
We got some fancy new switches that  -- no matter how much we fittled with them -- would not convince lldp that they had a name/description in addition to an id.

Suffers from the tests not really working reliably per #71
