### PR TITLE
Ldap user attribute support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,5 @@ Gemfile.lock
 .idea_modules
 
 /conf/solr/data/
-/conf/dev_authentication.conf
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,12 @@ test.rb
 *.db
 _site
 RUNNING_PID
-conf/solr/data/
 .DS_Store
 Gemfile.lock
 .idea
 .idea_modules
+
+/conf/solr/data/
+/conf/dev_authentication.conf
+
 

--- a/app/util/security/AuthenticationProviderConfig.scala
+++ b/app/util/security/AuthenticationProviderConfig.scala
@@ -50,6 +50,7 @@ object LdapAuthenticationProviderConfig extends Configurable {
   def groupsub = getString("groupsub")(ConfigValue.Required).get
   def groupAttribute = getString("groupAttribute")(ConfigValue.Required).get
   def host = getString("host")(ConfigValue.Required).get
+  def userAttribute = getString("userAttribute", "uid")
   def schema = getString("schema")(ConfigValue.Required).map(_.toLowerCase).get
   def searchbase = getString("searchbase")(ConfigValue.Required).get
   def usersub = getString("usersub")(ConfigValue.Required).get

--- a/app/util/security/LdapAuthenticationProvider.scala
+++ b/app/util/security/LdapAuthenticationProvider.scala
@@ -12,96 +12,152 @@ import javax.naming.directory._
 class LdapAuthenticationProvider() extends AuthenticationProvider {
 
   val config = LdapAuthenticationProviderConfig
-  override val authType = "ldap"
+  val authType = "ldap"
 
-  // LDAP values
-  def host = config.host
-  def searchbase = config.searchbase
-  def useSsl = config.useSsl match {
+  private def useSsl = config.useSsl match {
     case true => "ldaps"
     case _ => "ldap"
   }
-  def url = "%s://%s/%s".format(useSsl, host, searchbase)
-  def usersub = config.usersub
-  def groupsub = config.groupsub
-  def groupattrib = config.groupAttribute
+  private def host = config.host
+  private def searchbase = config.searchbase
+  private def userAttribute = config.userAttribute
+  private def groupAttribute = config.groupAttribute
+  private def usersub = config.usersub
+  // TODO This is not used anywhere, remove from here and docs
+  private def groupsub = config.groupsub
 
-  // setup for LDAP
+  private def url = "%s://%s/%s".format(useSsl, host, searchbase)
+
+  // Configuration for ldap connection context
   protected def env = Map(
     Context.INITIAL_CONTEXT_FACTORY -> "com.sun.jndi.ldap.LdapCtxFactory",
     Context.PROVIDER_URL -> url,
-    Context.SECURITY_AUTHENTICATION -> "simple")
+    Context.SECURITY_AUTHENTICATION -> "simple"
+  )
 
-  // returns uid=USERNAME,ou=people
+  /**
+   * The relative distinguished name
+   * @param username
+   * @return E.g. uid=jdoe,ou=people
+   */
   protected def getPrincipal(username: String): String = {
-    "uid=%s,%s".format(username, usersub)
+    "%s=%s,%s".format(userAttribute, username, usersub)
   }
 
-  // returns uid=USERNAME,ou=people,dc=example,dc=org
+  /**
+   * The complete distinguished name
+   * @param username
+   * @return E.g. uid=jdoe,ou=people,dc=example,dc=org
+   */
   protected def getSecurityPrincipal(username: String): String = {
     "%s,%s".format(getPrincipal(username), searchbase)
   }
 
-  // returns (&cn=*)(uniqueMember=uid=USERNAME,ou=people,dc=example,dc=org)
-  protected def groupQuery(username: String): String = {
+  /**
+   * @param username
+   * @return Search filter for user; e.g. (&cn=*)(uniqueMember=uid=jdoe,ou=people,dc=example,dc=org)
+   */
+  protected def groupSearchFilter(username: String): String = {
     if (config.isRfc2307Bis)
-      "(&(cn=*)(%s=%s))".format(groupattrib, getSecurityPrincipal(username))
+      "(&(cn=*)(%s=%s))".format(groupAttribute, getSecurityPrincipal(username))
     else
-      "(&(cn=*)(%s=%s))".format(groupattrib, username)
+      "(&(cn=*)(%s=%s))".format(groupAttribute, username)
   }
 
   logger.debug("LDAP URL: %s".format(url))
 
-  // Authenticate via LDAP
-  override def authenticate(username: String, password: String): Option[User] = {
+  /**
+   * Authenticate user & password against configured ldap host
+   * @param username
+   * @param password
+   * @return If authentication successful, the user; otherwise None
+   */
+  def authenticate(username: String, password: String): Option[User] = {
+    logContextEnvInfo(username)
+
     val userEnv = Map(
       Context.SECURITY_PRINCIPAL -> getSecurityPrincipal(username),
-      Context.SECURITY_CREDENTIALS -> password) ++ env
+      Context.SECURITY_CREDENTIALS -> password
+    ) ++ env
 
     var ctx: InitialDirContext = null
     try {
+      logger.trace("establishing context")
       ctx = new InitialDirContext(new JHashTable[String,String](userEnv.asJava))
-      val uid = getUid(getPrincipal(username), ctx)
+      logger.trace("established context")
+
+      val uid = getUid(username, ctx)
       require(uid > 0, "Unable to find UID for user")
+      logger.debug("Found uid=%s for user %s".format(uid, username))
+
       val groups = getGroups(username, ctx)
       val user = UserImpl(username, "*", groups.map { _._2 }.toSet, uid, true)
       logger.trace("Succesfully authenticated %s".format(username))
+
       Some(user)
     } catch {
       case e: AuthenticationException =>
         logger.info("Failed authentication for user %s with error %s".format(username, e.getMessage))
         None
       case e: Throwable =>
-        logger.info("Failed authentication", e)
+        logger.info("Authentication process failed. Check configuration?", e)
         None
     } finally {
       if (ctx != null) ctx.close
     }
   }
 
-  // Return UUID
-  protected def getUid(search: String, ctx: InitialDirContext): Int = {
-    val ctrl = new SearchControls
-    ctrl.setSearchScope(SearchControls.OBJECT_SCOPE)
-    val attribs = ctx.getAttributes(search)
+
+  /**
+   * INFO log environment and distinguished name details
+   * @param username
+   */
+  private def logContextEnvInfo(username: String) {
+    if (logger.isInfoEnabled) {
+      val dn = getSecurityPrincipal(username)
+
+      logger.info("Building context for dn -> %s with the following environment".format(dn))
+      env.foreach {
+        case (key, value) => {
+          logger.info("Context env key %s -> %s".format(key, value))
+        }
+      }
+    }
+  }
+
+  /**
+   * @param username
+   * @param ctx
+   * @return Ldap user id
+   */
+  protected def getUid(username: String, ctx: InitialDirContext): Int = {
+    val attribs = ctx.getAttributes(getPrincipal(username))
+
     attribs.get("uidNumber") match {
       case null => -1
       case attrib => attrib.get.asInstanceOf[String].toInt
     }
   }
 
+  /**
+   * @param username
+   * @param ctx
+   * @return Sequence of (group id, common name) tuples
+   */
   protected def getGroups(username: String, ctx: InitialDirContext): Seq[(Int,String)] = {
     val ctrl = new SearchControls
     ctrl.setSearchScope(SearchControls.SUBTREE_SCOPE)
-    val query = groupQuery(username)
+    val query = groupSearchFilter(username)
+
     val it = for (
-         result <- ctx.search("", query, ctrl);
-         attribs = result.asInstanceOf[SearchResult].getAttributes();
-         if attribs.get("cn") != null;
-         if attribs.get("gidNumber") != null;
-         cn = attribs.get("cn").get.asInstanceOf[String];
-         gidNumber = attribs.get("gidNumber").get.asInstanceOf[String].toInt
-       ) yield(gidNumber, cn)
+      result <- ctx.search("", query, ctrl);
+      attribs = result.asInstanceOf[SearchResult].getAttributes();
+      if attribs.get("cn") != null;
+      if attribs.get("gidNumber") != null;
+      cn = attribs.get("cn").get.asInstanceOf[String];
+      gidNumber = attribs.get("gidNumber").get.asInstanceOf[String].toInt
+    ) yield(gidNumber, cn)
+
     it.toSeq
   }
 }

--- a/conf/authentication.conf
+++ b/conf/authentication.conf
@@ -1,6 +1,0 @@
-authentication {
-
-  type = default
-  file.userfile = "conf/users.conf"
-
-}

--- a/conf/dev_authentication.conf
+++ b/conf/dev_authentication.conf
@@ -1,0 +1,7 @@
+authentication {
+
+  type = default
+  file.userfile = "conf/users.conf"
+
+}
+

--- a/conf/dev_base.conf
+++ b/conf/dev_base.conf
@@ -207,7 +207,6 @@ lshw {
   lshw.defaultNicCapacity=10000000000
 }
 
-# This file is git ignored, you can see authentication_reference.conf to get started
 include "dev_authentication.conf"
 
 # Set logging properties in logger.xml or dev_logger.xml

--- a/conf/dev_base.conf
+++ b/conf/dev_base.conf
@@ -207,7 +207,8 @@ lshw {
   lshw.defaultNicCapacity=10000000000
 }
 
-include "authentication.conf"
+# This file is git ignored, you can see authentication_reference.conf to get started
+include "dev_authentication.conf"
 
 # Set logging properties in logger.xml or dev_logger.xml
 

--- a/conf/dev_logger.xml
+++ b/conf/dev_logger.xml
@@ -14,14 +14,15 @@
   <logger name="play" level="INFO" />
   <logger name="application" level="TRACE" />
 
-  <logger name="configurable" level="DEBUG" />
+  <logger name="configurable" level="WARN" />
 
   <!-- Off these ones as they are annoying, and anyway we manage configuration ourself -->
   <logger name="com.avaje.ebean.config.PropertyMapLoader" level="OFF" />
-  <logger name="util.security.AuthenticationProvider" level="INFO" />
   <logger name="Privileges" level="INFO" />
   <logger name="com.avaje.ebeaninternal.server.core.XmlConfigLoader" level="OFF" />
   <logger name="com.avaje.ebeaninternal.server.lib.BackgroundThread" level="OFF" />
+  <logger name="ConfigWatchTask" level="WARN" />
+  <logger name="play.api.LoggerLike" level="WARN" />
 
   <!-- the httpclient debug logging is ridiculously chatty -->
   <logger name="httpclient.wire.content" level="WARN" />

--- a/conf/reference/authentication_reference.conf
+++ b/conf/reference/authentication_reference.conf
@@ -13,18 +13,22 @@ authentication {
   permissionsFile = "conf/permissions.yaml"
   adminGroup = [Infra]
 
+  # for type = ldap
   ldap {
-    host = "localhost"
-    groupAttribute = "uniqueMember"
-    # Valid schemas are rfc2307bis or rfc2307. The difference is in how groups
-    # are queried. RFC 2307 queries as groupAttribute=username, RFC 2307 BIS
-    # queries as groupAttribute=DN.
-    schema = "rfc2307bis"
-    searchbase = "dc=example,dc=org"
-    usersub = "ou=people"
-    groupsub = "ou=groups"
+      # Valid schemas are rfc2307bis or rfc2307. The difference is in how groups
+      # are queried. RFC 2307 queries as groupAttribute=username, RFC 2307 BIS
+      # queries as groupAttribute=DN.
+      schema = "rfc2307bis"
+
+      ssl = true
+      host = "localhost"
+      searchbase = "dc=example,dc=org"
+      userAttribute = "uid"
+      groupAttribute = "uniqueMember"
+      usersub = "ou=people"
   }
 
+  # for type = file
   file {
     userfile = "conf/users.conf"
   }


### PR DESCRIPTION
This will allow slightly more customization of how principals are referenced in ldap; specifically, if your primary rdn is not by uid, but rather by full name (e.g. uid=bvanevery versus cn=Benjamin VanEvery).  

Overall this code should be restructured to use a bind user to create the initial context and then use that context to look up the user. The returned user object can then be used to determine the relative distinguished name, which can be combined with the search base and then combined with the provided user password to create a new context. This described method would be more flexible for fitting on top of other types of ldap schemas. 