### PR TITLE
Mixed authentication modes

### DIFF
--- a/app/util/config/AppConfig.scala
+++ b/app/util/config/AppConfig.scala
@@ -36,9 +36,10 @@ trait AppConfig {
       import play.api.Play.current
       Some(current.configuration)
     } catch {
-      case e: RuntimeException =>
+      case e: RuntimeException => {
         Logger(getClass).error("No current play application configured")
         AppConfig.globalConfig
+      }
     }
   }.orElse(default).getOrElse(play.api.Configuration.from(Map.empty))
 }

--- a/app/util/config/ConfigAccessor.scala
+++ b/app/util/config/ConfigAccessor.scala
@@ -1,11 +1,13 @@
 package util
 package config
 
-import play.api.PlayException
+import play.api.{Logger, PlayException}
 import com.typesafe.config.{ConfigException, ConfigFactory, ConfigObject, ConfigValue => TypesafeConfigValue}
 import scala.collection.JavaConverters._
 import java.net.{MalformedURLException, URL}
 import java.util.concurrent.atomic.AtomicReference
+
+class ConfigurationException(msg: String) extends Exception(msg)
 
 // Provide access to values from an underlying configuration
 trait ConfigAccessor {
@@ -79,7 +81,7 @@ trait ConfigAccessor {
         cfgv match {
           case ConfigValue.Required =>
             val keyname = getFqNs(key)
-            throw new Exception("Required configuration %s not found".format(keyname))
+            throw new ConfigurationException("Required configuration %s not found".format(keyname))
           case _ =>
             None
         }
@@ -127,6 +129,8 @@ trait ConfigAccessor {
     underlying.flatMap(cfg => Option(p(cfg)))
   } catch {
     case e: ConfigException.Missing =>
+      Logger(getClass).warn("Missing value for key '%s'".format(path))
+
       None
   }
 }

--- a/app/util/config/Configurable.scala
+++ b/app/util/config/Configurable.scala
@@ -104,6 +104,7 @@ trait Configurable extends ConfigAccessor with AppConfig { self =>
         if (!skipValidation) {
           logger.debug("Validating configuration for %s".format(getClass.getName))
           validateConfig()
+          logger.trace("Validation successful for configuration for %s".format(getClass.getName))
         }
       } catch {
         case e =>

--- a/app/util/security/AuthenticationProvider.scala
+++ b/app/util/security/AuthenticationProvider.scala
@@ -54,13 +54,7 @@ object AuthenticationProvider {
     ConfigCache.create(AuthenticationProviderConfig.cachePermissionsTimeout, PermissionsLoader())
 
   def get(name: String): AuthenticationProvider = {
-    name match {
-      case "default" => Default
-      case "file" => new FileAuthenticationProvider()
-      case "ldap" => new LdapAuthenticationProvider()
-      case o =>
-        throw new Exception("Invalid auth type %s specified".format(name))
-    }
+    new MixedAuthenticationProvider(name)
   }
 
   def permissions(concern: String): Option[Set[String]] = {

--- a/app/util/security/AuthenticationProviderConfig.scala
+++ b/app/util/security/AuthenticationProviderConfig.scala
@@ -2,9 +2,7 @@ package util
 package security
 
 import util.config.{Configurable, ConfigValue}
-import collins.permissions.PermissionsHelper
 import collins.validation.File
-import java.io.{File => IoFile}
 
 object AuthenticationProviderConfig extends Configurable {
   override val namespace = "authentication"
@@ -33,6 +31,7 @@ object FileAuthenticationProviderConfig extends Configurable {
 
   override protected def validateConfig() {
     if (AuthenticationProviderConfig.authType == "file") {
+      logger.debug("User authentication file " + userfile)
       File.requireFileIsReadable(userfile)
     }
   }

--- a/app/util/security/FileAuthenticationProvider.scala
+++ b/app/util/security/FileAuthenticationProvider.scala
@@ -37,3 +37,4 @@ class FileAuthenticationProvider() extends AuthenticationProvider {
     "{SHA}" + new BASE64Encoder().encode(MessageDigest.getInstance("SHA1").digest(s.getBytes()))
   }
 }
+

--- a/app/util/security/MixedAuthenticationProvider.scala
+++ b/app/util/security/MixedAuthenticationProvider.scala
@@ -1,0 +1,60 @@
+package util.security
+
+import models.User
+
+
+/**
+ * Exception encountered during authentication phase
+ */
+class AuthenticationException(msg: String) extends Exception(msg)
+
+/**
+ * Provides authentication by a variety of methods
+ */
+class MixedAuthenticationProvider(types: String) extends AuthenticationProvider {
+
+  /**
+   * @return The authorization type provided by this class
+   */
+  def authType: String = types
+
+  /**
+   * Ordered list of permitted authentication types
+   */
+  private val configuredTypes = types.split(",").toSeq.map(_.trim)
+
+  /**
+   * Attempt to authenticate user by each method specified in :types
+   * @return Authenticated user or none
+   */
+  def authenticate(username: String, password: String): Option[User] = {
+    logger.debug("Beginning to try authentication types")
+
+    // Iterate over the types lazily, such that if one method passes, iteration stops
+    configuredTypes.view.flatMap({
+      case "default" => {
+        logger.trace("mock authentication type")
+        val defaultProvider = AuthenticationProvider.Default
+        val user = defaultProvider.authenticate(username, password)
+        logger.debug("Tried mock authentication for %s, got back %s".format(username, user))
+        user
+      }
+      case "file" => {
+        logger.trace("file authentication type")
+        val fileProvider = new FileAuthenticationProvider()
+        val user = fileProvider.authenticate(username, password)
+        logger.debug("Tried file authentication for %s, got back %s".format(username, user))
+        user
+      }
+      case "ldap" => {
+        val ldapProvider = new LdapAuthenticationProvider()
+        val user = ldapProvider.authenticate(username, password)
+        logger.debug("Tried ldap authentication for %s, got back %s".format(username, user))
+        user
+      }
+      case t => {
+        throw new AuthenticationException("Invalid authentication type provided: " + t)
+      }
+    }).headOption
+  }
+}

--- a/test/util/security/AuthenticationProviderSpec.scala
+++ b/test/util/security/AuthenticationProviderSpec.scala
@@ -26,7 +26,7 @@ object AuthenticationProviderSpec extends Specification with _root_.test.Resourc
       _root_.util.config.AppConfig.globalConfig = Some(config)
       FileAuthenticationProviderConfig.initialize
       val provider = AuthenticationProvider.get("file")
-      provider must haveClass[FileAuthenticationProvider]
+
       val users = Seq(
         ("blake", "password123", Set("engineering")),
         ("testuser", "FizzBuzzAbc", Set("ny","also"))

--- a/test/util/security/MixedAuthenticationProviderSpec.scala
+++ b/test/util/security/MixedAuthenticationProviderSpec.scala
@@ -1,0 +1,78 @@
+package util.security
+
+import org.specs2.Specification
+import org.specs2.specification.Fragments
+import play.api.Configuration
+import models.User
+import util.config.ConfigurationException
+
+/**
+ * Please provide a concise description
+ */
+class MixedAuthenticationProviderSpec extends Specification with _root_.test.ResourceFinder {
+  def is: Fragments =
+    "The " + classOf[MixedAuthenticationProviderSpec] + " should" ^
+      "Authenticate users in htaccess type files" ! authUser() ^
+      "Stop iterating if a user is found"         ! shortCircuit() ^
+      "Return None if no method succeeds"         ! authBadUser() ^
+      "Attempt each method in order"              ! allTypes() ^
+      "Fail because ldap is not stubbed out"      ! attemptLdap() ^
+      "Fail when bad type specified"              ! enforceKnownTypes() ^
+    end
+
+  def configure() {
+    val authFile = findResource("htpasswd_users")
+    val configData = Map(
+      "authentication.type" -> "file",
+      "authentication.permissionsFile" -> "conf/permissions.yaml",
+      "userfile" -> authFile.getAbsolutePath
+    )
+
+    val config = Configuration.from(configData)
+    _root_.util.config.AppConfig.globalConfig = Some(config)
+    FileAuthenticationProviderConfig.initialize()
+  }
+
+  def authUser() = {
+    configure()
+
+    val prov = new MixedAuthenticationProvider("file")
+    val user = prov.authenticate("blake", "password123")
+
+    (user must beSome[User]) and (user.get.username must_== "blake")
+  }
+
+  def shortCircuit() = {
+    // If ldap is attempted, this will fail because there is no configuration registered
+    // ...thus this test passes by virtue of such an exception not being raised
+    val prov = new MixedAuthenticationProvider("file, ldap")
+    val user = prov.authenticate("blake", "password123")
+
+    (user must beSome[User]) and (user.get.username must_== "blake")
+  }
+
+  def authBadUser() = {
+    val prov = new MixedAuthenticationProvider("file")
+    val user = prov.authenticate("blake", "badpassword")
+
+    user must beNone
+  }
+
+  def allTypes() = {
+    val prov = new MixedAuthenticationProvider("file, default, ldap")
+    val user = prov.authenticate("blake", "admin:first")
+
+    (user must beSome[User]) and (user.get.username must_== "blake")
+  }
+
+  def attemptLdap() = {
+    // The first two will fail, and then it will attemp ldap and fail
+    val prov = new MixedAuthenticationProvider("file, default, ldap")
+    prov.authenticate("ldapuser", "doesntmatter") must throwA[ConfigurationException](message = "Required configuration authentication.ldap.host not found")
+  }
+
+  def enforceKnownTypes() = {
+    val prov = new MixedAuthenticationProvider("unknown")
+    prov.authenticate("", "") must throwAn[AuthenticationException](message = "Invalid authentication type provided: unknown")
+  }
+}


### PR DESCRIPTION
Configure multiple authentication methods in order. This allows users to specify the preferred method of authentication, but provide a fallback if that fails.

We would rather not create service users in ldap for the purpose of interacting with collins, and this allows us to do without affecting existing users and perhaps providing flexibility for future adopters.

One note regarding the tests --
This test passes individually (i.e. `test-only util.security.MixedAuthenticationProviderSpec`), but fails as part of the global `play test`. This is because configurations from previous tests bleed over between tests. At some point the `authentication_reference.conf` file is being loaded and polluting the configurations for ldap, which makes the ldap provider actually attempt a lookup and fail. 
