### PR TITLE
Scripts fixes

### DIFF
--- a/scripts/collins.sh
+++ b/scripts/collins.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/env sh
+#! /usr/bin/env bash
 #
 # collins - groovy kind of love
 #

--- a/scripts/gen_passwords.sh
+++ b/scripts/gen_passwords.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 charArray=( 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 'u' 'v' 'w' 'x' 'y' 'z' 'A' 'B' 'C' 'D' 'E' 'F' 'G' 'H' 'I' 'J' 'K' 'L' 'M' 'N' 'O' 'P' 'Q' 'R' 'S' 'T' 'U' 'V' 'W' 'X' 'Y' 'Z' )
 numArray=( 0 1 2 3 4 5 6 7 8 9 )

--- a/scripts/populate.sh
+++ b/scripts/populate.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 URL="http://localhost:9000/api/asset"
 LshwFiles="10g

--- a/scripts/populate_partial.sh
+++ b/scripts/populate_partial.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 URL="http://localhost:9000/api/asset"
 LshwFiles="10g


### PR DESCRIPTION
This is two fixes to the scripts.

Firstly, explicitly use bash.  As mentioned in pull request #97, on systems that actually have sh, and sh isn't just a symlink to bash, these scripts fail.

Secondly, the populate script had a call to 'realpath'.  That executable isn't on many systems, and it isn't even necessary for the script to work, so I removed it.
