### PR TITLE
Trim strings that are formatted to go into solr queries

### DIFF
--- a/app/collins/solr/StringValueFormat.scala
+++ b/app/collins/solr/StringValueFormat.scala
@@ -101,7 +101,7 @@ object StringValueFormat {
     )
     val (_,_, strim, etrim, format) = states.find{x => x._1 && x._2}.get
     try {
-      SolrStringValue(rawStr.substring(strim, rawStr.length - (etrim)), format)
+      SolrStringValue(rawStr.substring(strim, rawStr.length - (etrim)).trim(), format)
     } catch {
       case e =>
         logger.error("Error converting %s to SolrString: %s".format(rawStr, e.getMessage), e)


### PR DESCRIPTION
Before this patch, if you searched for a string (say hostname) with leading whitespace, the result would be all assets, whereas if you had trailing whitespace, you would always get the empty set.
