### PR TITLE
Things I needed to do to get collins to run in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ MAINTAINER Johannes 'fish' Ziemke <fish@docker.com>
 WORKDIR /collins
 
 RUN apt-get update
-RUN apt-get -y -q upgrade
+#RUN apt-get -y -q upgrade
 
 # Disable upstart
-RUN dpkg-divert --local --rename --add /sbin/initctl && ln -s /bin/true /sbin/initctl
+#RUN dpkg-divert --local --rename --add /sbin/initctl && ln -s /bin/true /sbin/initctl
 
 # We can't mknod, so fake it
 RUN apt-get -y -q install fakeroot && fakeroot apt-get -y -q install fuse

--- a/conf/metrics-reporter-config.yaml
+++ b/conf/metrics-reporter-config.yaml
@@ -1,0 +1,21 @@
+csv:
+  -
+    outdir: '/tmp/metrics/crazy-debugging'
+    period: 2
+    timeunit: 'MINUTES'
+ganglia:
+  -
+    period: 60
+    timeunit: 'SECONDS'
+    hosts:
+      - host: 'gmond.domain.local'
+        port: 8649
+      - host: 'gmond-backup.domain.local'
+        port: 8649
+graphite:
+  -
+    period: 120
+    timeunit: 'SECONDS'
+    hosts:
+     - host: 'graphite-server.domain.local'
+        port: 2003


### PR DESCRIPTION
conf/metrics-reporter-config.yaml was missing. Collins won't start without it, even though the plugin is disabled.

Minor fixes to the Docker.md and Dockerfile to get Collins running in docker.
