### PR TITLE
dont parse config yaml if plugin is disabled

### DIFF
--- a/app/util/plugins/MetricsReporterConfig.scala
+++ b/app/util/plugins/MetricsReporterConfig.scala
@@ -13,9 +13,9 @@ object MetricsReporterConfig extends Configurable {
   def enabled = getBoolean("enabled", false)
   def configFile = getString("configFile")(ConfigValue.Required).get
 
-  override def validateConfig() {
-    enabled
-    File.requireFileIsReadable(configFile)
+  override def validateConfig() = enabled match {
+    case true => File.requireFileIsReadable(configFile)
+    case _    => false
   }
 
 }


### PR DESCRIPTION
Allows collins to start up if missing the yaml file when the plugin is disabled.
