### PR TITLE
allow multiple product strings to be matched for flash disk detection

### DIFF
--- a/app/util/config/LshwConfig.scala
+++ b/app/util/config/LshwConfig.scala
@@ -6,6 +6,7 @@ object LshwConfig extends Configurable {
   override val referenceConfigFilename = "lshw_reference.conf"
 
   def flashProduct = getString("flashProduct", "flashmax").toLowerCase
+  def flashProducts = Set(flashProduct) ++ getStringSet("flashProducts", Set[String]()).map(s => s.toLowerCase)
   def flashSize = getLong("flashSize", 1400000000000L)
   def includeDisabledCpu = getBoolean("includeDisabledCpu", false)
   def includeEmptySocket = getBoolean("includeEmptySocket", false)
@@ -13,6 +14,7 @@ object LshwConfig extends Configurable {
 
   override protected def validateConfig() {
     flashProduct
+    flashProducts
     flashSize
     includeDisabledCpu
     includeEmptySocket

--- a/app/util/parsers/LshwParser.scala
+++ b/app/util/parsers/LshwParser.scala
@@ -100,7 +100,7 @@ class LshwParser(txt: String) extends CommonParser[LshwRepresentation](txt) {
         case size => ByteStorageUnit(size.toLong)
       }
       Disk(size, _type, asset.description, asset.product, asset.vendor)
-    case n if (n \ "@class" text) == "memory" && (n \ "product" text).toLowerCase.contains(LshwConfig.flashProduct) =>
+    case n if (n \ "@class" text) == "memory" && LshwConfig.flashProducts.exists(s => (n \ "product" text).toLowerCase.contains(s)) =>
       val asset = getAsset(n)
       val size = ByteStorageUnit(LshwConfig.flashSize)
       Disk(size, Disk.Type.Flash, asset.description, asset.product, asset.vendor)

--- a/conf/dev_base.conf
+++ b/conf/dev_base.conf
@@ -199,7 +199,7 @@ ipmi {
 }
 
 lshw {
-  flashProduct="flashmax"
+  flashProducts = ["fusionio", "tachION", "flashmax"]
   flashSize="1400000000000"
 
   # For assets whose NIC capacity cannot be determined


### PR DESCRIPTION
Allows better support for environments with multiple models/vendors of PCIe flash disks. I will create a separate PR to update documentation indicating that `lshw.flashProduct` is deprecated, and `lshw.flashProducts` is the new feature variable.
