### PR TITLE
Fix Dockerfile

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -14,10 +14,11 @@ RUN apt-get -y -q install fakeroot && fakeroot apt-get -y -q install fuse
 RUN apt-get install -y -q wget unzip default-jre default-jdk git
 
 RUN wget http://download.playframework.org/releases/play-2.0.4.zip && unzip play-2.0.4.zip
-RUN for dir in /collins /var/log/collins /var/run/collins; do mkdir $dir; chown nobody $dir; done
-ADD RUN git clone https://github.com/tumblr/collins.git /collins
+RUN for dir in /var/log/collins /var/run/collins; do mkdir $dir; chown nobody $dir; done
+RUN git clone https://github.com/tumblr/collins.git /collins/collins
+WORKDIR /collins/collins
 
-RUN ./play-2.0.4/play compile stage
+RUN ../play-2.0.4/play compile stage
 
 EXPOSE 9000
 RUN printf '#!/bin/sh\nexec java -cp "target/staged/*" -Dpidfile.path=/dev/null -Ddb.collins.url="jdbc:$(echo $DB_PORT|sed 's/^tcp/mysql/')/collins?autoReconnect=true&interactiveClient=true" $@' > run.sh && chmod a+x run.sh


### PR DESCRIPTION
For security reasons, Dockerfiles have no access to parent directories, so we can't do ADD ../../ or something like that.
If having the Dockerfile in root is a no go for you, I can change it to do a git checkout in a RUN statement. Although it's better to use ADD because:
- you can build collins without depending on github as long as you have the code
- you don't need to check out the repo twice
- ADD is a cache breaker, RUN not. So there is no easy way to rebuild collins without rerunning all steps in the Dockerfile
