### PR TITLE
Avoid querying the database for an asset when adding an asset to the lis...

### DIFF
--- a/app/collins/solr/SolrUpdater.scala
+++ b/app/collins/solr/SolrUpdater.scala
@@ -42,14 +42,12 @@ class AssetSolrUpdater extends Actor {
    */
   def receive = {
     case asset: Asset =>
-      if (shouldIndex(asset)) {
-        set.add(asset.tag)
-        if (scheduled.compareAndSet(false, true)) {
-          logger.debug("Scheduling update, saw %s".format(asset.tag))
-          context.system.scheduler.scheduleOnce(10 milliseconds, self, Reindex)
-        } else {
-          logger.trace("Not scheduling update, saw %s".format(asset.tag))
-        }
+      set.add(asset.tag)
+      if (scheduled.compareAndSet(false, true)) {
+        logger.debug("Scheduling update, saw %s".format(asset.tag))
+        context.system.scheduler.scheduleOnce(10 milliseconds, self, Reindex)
+      } else {
+        logger.trace("Not scheduling update, saw %s".format(asset.tag))
       }
     case Reindex =>
       if (scheduled.get == true) {
@@ -63,11 +61,6 @@ class AssetSolrUpdater extends Actor {
         scheduled.set(false)
       }
   }
-
-  protected def shouldIndex(asset: Asset): Boolean =
-    Asset.findByTag(asset.tag).map { oasset =>
-      true
-    }.getOrElse(false)
 }
 
 class AssetLogSolrUpdater extends Actor {


### PR DESCRIPTION
...t of

asset to index in Solr. The same query is repeated during reindexing, lets just do it once.

@madallab @Primer42 
Obsoletes https://github.com/tumblr/collins/pull/176
