### PR TITLE
add some fields to asset_meta that are useful

### DIFF
--- a/conf/evolutions/collins/12.sql
+++ b/conf/evolutions/collins/12.sql
@@ -4,6 +4,6 @@
 
 INSERT INTO asset_meta (name, priority, label, description) VALUES ('HOSTNAME', 0, 'Hostname', 'Hostname of asset');
 INSERT INTO asset_meta (name, priority, label, description) VALUES ('NODECLASS', 0, 'Nodeclass', 'Nodeclass of asset');
-INSERT INTO asset_meta (name, priority, label, description) VALUES ('POOL', 0, 'Pool', 'Pool');
-INSERT INTO asset_meta (name, priority, label, description) VALUES ('PRIMARY_ROLE', 0, 'Primary Role', 'Primary role of host or asset');
-INSERT INTO asset_meta (name, priority, label, description) VALUES ('SECONDARY_ROLE', 0, 'Secondary Role', 'Secondary role of host or asset');
+INSERT INTO asset_meta (name, priority, label, description) VALUES ('POOL', 0, 'Pool', 'Groups related assets spanning multiple functional roles');
+INSERT INTO asset_meta (name, priority, label, description) VALUES ('PRIMARY_ROLE', 0, 'Primary Role', 'Primary functional role of asset');
+INSERT INTO asset_meta (name, priority, label, description) VALUES ('SECONDARY_ROLE', 0, 'Secondary Role', 'Secondary functional role of asset');


### PR DESCRIPTION
@maddalab @Primer42 This will populate the asset_meta table with some useful fields that are missing from the default install. new asset_meta values inserted via API have priority -1, which means they are totally excluded from the search page. This isnt documented anywhere unfortunately :(

This will provide a bit nicer out of the box experience for new users...
