### PR TITLE
remove minimum Contact length

### DIFF
--- a/app/controllers/actions/asset/ProvisionUtil.scala
+++ b/app/controllers/actions/asset/ProvisionUtil.scala
@@ -32,7 +32,7 @@ trait ProvisionUtil { self: SecureAction =>
 
   val provisionForm = Form(tuple(
         "profile" -> text,
-        "contact" -> text(3),
+        "contact" -> text,
         "suffix" -> optional(text(3)),
         "primary_role" -> optional(text),
         "pool" -> optional(text),


### PR DESCRIPTION
1 or 2 letter contacts are legitimate in non-Hipchat contexts.
