### PR TITLE
Gabe portable init

### DIFF
--- a/scripts/collins.sh
+++ b/scripts/collins.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # collins - groovy kind of love
 # http://tumblr.github.io/collins/#about
 #


### PR DESCRIPTION
@roymarantz @dallasmarlow @maddalab @Primer42 No more daemon! Just use nohup, as it is way more portable. Also, move to using LSB init functions for status.
