### PR TITLE
Remove logging if the config is missing

### DIFF
--- a/app/util/config/ConfigAccessor.scala
+++ b/app/util/config/ConfigAccessor.scala
@@ -129,8 +129,6 @@ trait ConfigAccessor {
     underlying.flatMap(cfg => Option(p(cfg)))
   } catch {
     case e: ConfigException.Missing =>
-      Logger(getClass).warn("Missing value for key '%s'".format(path))
-
       None
   }
 }


### PR DESCRIPTION
Attempting to log here causes collins to complain, and everything
can handle it if this returns `None` anyway

@byxorna
