### PR TITLE
strip dockerfile down to be half the final size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN git clone https://github.com/tumblr/collins.git /build/collins && \
     git rev-parse HEAD > VERSION && \
     echo "Building Collins $(cat VERSION)" && \
     java -version 2>&1 && \
-    PLAY_CMD=/build/play-2.0.8/play /build/package.sh && \
+    PLAY_CMD=/build/play-2.0.8/play ./scripts/package.sh && \
     unzip -q /build/collins/target/collins.zip -d /opt/ && \
     rm -rf /build && \
     chown -R collins /opt/collins


### PR DESCRIPTION
@maddalab @Primer42 This reduces the size of the final docker container from ~1.4g to ~600m. We do the build and deploy in one RUN, so we dont leave any files around that will bloat up the layer FS.
