### PR TITLE
fix iDataLength being a string screwing up paging logs

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -386,7 +386,7 @@ $(document).ready(function() {
     var oTable;
     var dataSrc = e.attr('data-source');
     var columns = window[e.attr('data-cols')];
-    var rows = e.attr('data-size') || 10;
+    var rows = parseInt(e.attr('data-size'),10) || 10;
 
     var typeLocation = false;
     var tagLocation = false;


### PR DESCRIPTION
@Primer42 @maddalab If the logs loaded via ajax in log pager on asset show were < total number of logs, using the next button to page through them would cause issues due to how we were pulling the page size out of the dom. (ever seen this? Showing 0,251 to 1,336 of 1,336 entries). This ensures that the iDataLength element in DataTables is an int, so adding to it works like numbers, not strings. 
