### PR TITLE
Ensures the pid directory exists

### DIFF
--- a/scripts/collins.sh
+++ b/scripts/collins.sh
@@ -42,7 +42,9 @@ PID_DIRECTORY="/var/run/$APP_NAME"
 pidfile="$PID_DIRECTORY/$APP_NAME.pid"
 
 # Ensures the PID_DIRECTORY exists in order to survive hard reboots. 
-mkdir -p $PID_DIRECTORY 
+if [[ ! -d $PID_DIRECTORY ]] ; then
+  mkdir -p $PID_DIRECTORY 
+fi
 
 function running() {
   [[ ! -s $pidfile ]] && return 1


### PR DESCRIPTION
Ensures the PID_DIRECTORY exists in order to survive hard reboots. When the machine gets restarted, the script cannot successfully start because the /var/run/$APP_NAME directory does not exist.

This commit addresses this issue creating the directory if it is not existent.
