### PR TITLE
allow us to do trusted builds for the container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+_site
+target
+support

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,53 +1,44 @@
-FROM centos:centos6
+FROM java:7
 MAINTAINER Gabe Conradi <gabe@tumblr.com>
-#NOTE: you should use vendorize this container by deploying your own production.conf to /opt/collins/conf/production.conf
-# as well as other configs, like profiles.yaml, permissions.yaml, users.conf, database.conf, validations.conf, and authentication.conf
 
-RUN yum -y update && yum install -y wget zip unzip git java-1.6.0-openjdk java-1.6.0-openjdk-devel && yum -y clean all
+RUN apt-get update && apt-get install -y zip unzip && rm -r /var/lib/apt/lists/*
+
 RUN useradd -Ur -d /opt/collins collins
-RUN for dir in /build /var/log/collins /var/run/collins; do mkdir $dir; chown collins $dir; done
-ENV JAVA_HOME /usr/lib/jvm/java-1.6.0-openjdk-1.6.0.0.x86_64/jre
-ENV APP_HOME /opt/collins
-ENV LOG_HOME /var/log/collins
+RUN for dir in /build /build/collins /var/log/collins /var/run/collins; do mkdir $dir; chown collins $dir; done
+ENV APP_HOME=/opt/collins LOG_HOME=/var/log/collins LISTEN_PORT=9000
 
 WORKDIR /build
-
-# set up the JCE for runtime. To build this image, you need to grab the JCE zip from http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html
-ADD ./jce_policy-6.zip /build/jce_policy-6.zip
-RUN unzip -q jce_policy-6.zip && cp /build/jce/*jar $JAVA_HOME/lib/security/ && rm -f jce_policy-6.zip
-
 # get Play, Collins, build, and deploy it to /opt/collins
-RUN git clone https://github.com/tumblr/collins.git /build/collins && \
-    echo "Fetching Play 2.0.8" && \
+COPY . /build/collins
+RUN echo "Fetching Play 2.0.8" && \
     wget -q http://downloads.typesafe.com/play/2.0.8/play-2.0.8.zip -O /build/play-2.0.8.zip && \
     unzip -q ./play-2.0.8.zip && \
-    cd /build/collins && \
-    git rev-parse HEAD > VERSION && \
-    echo "Building Collins $(cat VERSION)" && \
+    cd collins && \
     java -version 2>&1 && \
     PLAY_CMD=/build/play-2.0.8/play ./scripts/package.sh && \
     unzip -q /build/collins/target/collins.zip -d /opt/ && \
-    rm -rf /build && \
+    cd / && rm -rf /build && \
     chown -R collins /opt/collins
 
-# and add in all the default configs we want in this build
-# these are the things you ought to change when vendorizing
-ADD ./conf/docker/validations.conf /opt/collins/conf/validations.conf
-ADD ./conf/docker/authentication.conf /opt/collins/conf/authentication.conf
-ADD ./conf/docker/database.conf /opt/collins/conf/database.conf
-ADD ./conf/docker/production.conf /opt/collins/conf/production.conf
-ADD ./conf/docker/users.conf /opt/collins/conf/users.conf
-ADD ./conf/docker/profiles.yaml /opt/collins/conf/profiles.yaml
-ADD ./conf/docker/permissions.yaml /opt/collins/conf/permissions.yaml
-ADD ./conf/docker/logger.xml /opt/collins/conf/logger.xml
+# Add in all the default configs we want in this build so collins can run.
+# Override /opt/collins/conf with your own configs with -v
+COPY conf/docker/validations.conf     /opt/collins/conf/validations.conf
+COPY conf/docker/authentication.conf  /opt/collins/conf/authentication.conf
+COPY conf/docker/database.conf        /opt/collins/conf/database.conf
+COPY conf/docker/production.conf      /opt/collins/conf/production.conf
+COPY conf/docker/users.conf           /opt/collins/conf/users.conf
+COPY conf/docker/profiles.yaml        /opt/collins/conf/profiles.yaml
+COPY conf/docker/permissions.yaml     /opt/collins/conf/permissions.yaml
+COPY conf/docker/logger.xml           /opt/collins/conf/logger.xml
+
 RUN chown -R collins /opt/collins
 
 WORKDIR /opt/collins
 USER collins
-EXPOSE 9000
+EXPOSE $LISTEN_PORT
 CMD /usr/bin/java -server \
       -Dconfig.file=$APP_HOME/conf/production.conf \
-      -Dhttp.port=9000 \
+      -Dhttp.port=$LISTEN_PORT \
       -Dlogger.file=$APP_HOME/conf/logger.xml \
       -Dnetworkaddress.cache.ttl=1 \
       -Dnetworkaddress.cache.negative.ttl=1 \


### PR DESCRIPTION
@Primer42 @maddalab @roymarantz 
This changes the container over to using the supported java:7 container, which includes the JCE policy files. The build is much simpler now, and allows us to setup the collins container as a trusted build (read: automatic) instead of manual as it is now.