### PR TITLE
fix dockerfile for screwed up env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN apt-get update && apt-get install -y zip unzip && rm -r /var/lib/apt/lists/*
 
 RUN useradd -Ur -d /opt/collins collins
 RUN for dir in /build /build/collins /var/log/collins /var/run/collins; do mkdir $dir; chown collins $dir; done
-ENV APP_HOME=/opt/collins LOG_HOME=/var/log/collins
+ENV APP_HOME=/opt/collins \
+    LOG_HOME=/var/log/collins
 
 WORKDIR /build
 # get Play, Collins, build, and deploy it to /opt/collins


### PR DESCRIPTION
@Primer42 @maddalab FYI this is a break fix.
The APP_HOME env var in the docker image was APP_HOME=/opt/collinsLOG_HOME=/var/log/collins preventing classes from being loaded.