### PR TITLE
fix build on docker hub at 1.3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update && apt-get install -y zip unzip && rm -r /var/lib/apt/lists/*
 
 RUN useradd -Ur -d /opt/collins collins
 RUN for dir in /build /build/collins /var/log/collins /var/run/collins; do mkdir $dir; chown collins $dir; done
-ENV APP_HOME=/opt/collins \
-    LOG_HOME=/var/log/collins
+ENV APP_HOME=/opt/collins
+ENV LOG_HOME=/var/log/collins
 
 WORKDIR /build
 # get Play, Collins, build, and deploy it to /opt/collins


### PR DESCRIPTION
@Primer42 @maddalab @hsmade
This fixes the incorrect automated build on the docker hub. They are using an older version of docker (1.3.3) which gets confused with multiple environment vars in a single ENV statement.

https://github.com/tumblr/collins/commit/f0b8be6e58974dda66d61306b6ef7a274c736757#commitcomment-9456823

Bad (built on 1.3.3 in hub)
```
-> $ docker inspect tumblr/collins:latest|grep -A4 Env
        "Env": [
            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
            "JAVA_VERSION=7u71",
            "JAVA_DEBIAN_VERSION=7u71-2.5.3-2",
            "APP_HOME=/opt/collins=LOG_HOME=/var/log/collins"
```
Good: (built with 1.4.1 or separate ENV lines)
```
-> $ docker inspect f09894e72077|grep -A5 Env
        "Env": [
            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
            "JAVA_VERSION=7u71",
            "JAVA_DEBIAN_VERSION=7u71-2.5.3-2",
            "APP_HOME=/opt/collins",
            "LOG_HOME=/var/log/collins"
```