### PR TITLE
add status:state label on asset show pages

### DIFF
--- a/app/util/views/Summary.scala
+++ b/app/util/views/Summary.scala
@@ -2,6 +2,7 @@ package util
 package views
 
 import models.Asset
+import models.Status
 
 import play.api.mvc.Content
 import play.api.templates.Html
@@ -29,7 +30,8 @@ trait Summarizer[T] {
 case class AssetSummary(template: String) extends Summarizer[Asset] {
   override val replacementMap = Map(
     "assetType" -> getAssetType _,
-    "hostname" -> getHostname _
+    "hostname" -> getHostname _,
+    "statusLabel" -> getStatusLabel _
   )
 
   def getAssetType(asset: Asset): String = {
@@ -38,6 +40,27 @@ case class AssetSummary(template: String) extends Summarizer[Asset] {
       case false => asset.getType().label
     }
   }
+  def getStatusLabel(asset: Asset): String = {
+    val state_string = asset.getState match {
+      case Some(st) => ":%s" format st.name
+      case None => ""
+    }
+    val state_descr = asset.getState match {
+      case Some(st) => " - %s" format st.description
+      case None => ""
+    }
+    val badge_class = asset.getStatus.name match {
+      case "Allocated"                    => "label-primary"
+      case "Cancelled" | "Decommissioned" => "label-default"
+      case "Maintenance"                  => "label-danger"
+      case "Incomplete" | "New"           => "label-warning"
+      case "Provisioned" | "Provisioning" => "label-info"
+      case "Unallocated"                  => "label-success"
+      case _                              => "label-default"
+    }
+    "<span data-rel=\"tooltip\" data-original-title=\"" + asset.getStatus.description + state_descr +
+      "\" data-placement=\"bottom\"  class=\"label " + badge_class + "\">" + asset.getStatusName + state_string + "</span>"
+  }
   def getHostname(asset: Asset): String = {
     asset.getMetaAttribute("HOSTNAME").map(_.getValue).getOrElse(asset.tag)
   }
@@ -45,7 +68,7 @@ case class AssetSummary(template: String) extends Summarizer[Asset] {
 
 object Summary {
   def apply(asset: Asset): Content = {
-    val template = "<h1>{assetType} <small>{hostname}</small></h1>"
+    val template = "<h1>{assetType} <small>{hostname}</small></h1><h4 class=\"asset-status-label\">{statusLabel}</h4>"
     AssetSummary(template).get(asset)
   }
 }

--- a/app/views/asset/show_menu.scala.html
+++ b/app/views/asset/show_menu.scala.html
@@ -6,7 +6,7 @@
 @import _root_.collins.provisioning.ProvisionerConfig
 @import _root_.controllers.Permissions
 
-<div class="page-header">
+<div class="page-header" style="position:relative;">
   @Summary(aa.asset)
 </div>
 

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -219,3 +219,9 @@ p { padding: 5px 0; }
   /* override control-label from bootstrap in form-horizontal */
   text-align:inherit !important;
 }
+.page-header h4 {
+  /* position the label in the top right of the page-header only on asset show_menu view*/
+  position:absolute;
+  top:0;
+  right:0;
+}


### PR DESCRIPTION
@maddalab @Primer42 This makes it easier to see what status an asset is in, even if you are on another menu pill. Nice to have to prevent someone from rebooting the wrong box when clicking through tabs :)
The label has a hover of the status+state description, just to be a fancy pants. It is also right justified to the top+right of the page header, so it looks clean (not terribly obvious from the screen shots).

![screen shot 2015-01-30 at 3 58 16 pm](https://cloud.githubusercontent.com/assets/130194/5983261/d58b9ff4-a899-11e4-8cb8-aafdabd13a29.png)
![screen shot 2015-01-30 at 3 58 43 pm](https://cloud.githubusercontent.com/assets/130194/5983264/d9bc2daa-a899-11e4-97e0-23bc516940b4.png)
![screen shot 2015-01-30 at 3 59 18 pm](https://cloud.githubusercontent.com/assets/130194/5983266/dc3ecd80-a899-11e4-8826-a8264bde6dce.png)
![screen shot 2015-01-30 at 3 59 53 pm](https://cloud.githubusercontent.com/assets/130194/5983268/dee97954-a899-11e4-94d0-6c0fd9a39fff.png)
![screen shot 2015-01-30 at 4 02 22 pm](https://cloud.githubusercontent.com/assets/130194/5983272/e1d3d52e-a899-11e4-9203-f7d922ec412a.png)
