### PR TITLE
replaced Twitter futures with Scala futures

### DIFF
--- a/app/collins/power/management/PowerManagement.scala
+++ b/app/collins/power/management/PowerManagement.scala
@@ -1,7 +1,7 @@
 package collins.power.management
 
 import collins.power._
-import com.twitter.util.Future
+import scala.concurrent.Future
 import models.Asset
 
 trait PowerManagement {

--- a/app/collins/provisioning/Provisioner.scala
+++ b/app/collins/provisioning/Provisioner.scala
@@ -2,7 +2,7 @@ package collins.provisioning
 
 import models.Asset
 import play.api.Logger
-import com.twitter.util.Future
+import scala.concurrent.Future
 import collins.shell.CommandResult
 
 trait Provisioner {

--- a/app/collins/softlayer/SoftLayer.scala
+++ b/app/collins/softlayer/SoftLayer.scala
@@ -4,7 +4,7 @@ import collins.power.management.PowerManagement
 import models.Asset
 
 import play.api.Logger
-import com.twitter.util.Future
+import scala.concurrent.Future
 import java.net.URL
 
 trait SoftLayer extends PowerManagement {

--- a/app/controllers/Api.scala
+++ b/app/controllers/Api.scala
@@ -4,15 +4,12 @@ import actors._
 import models.Asset
 import util._
 import util.concurrent.BackgroundProcessor
-import util.plugins.Callback
 import util.views.Formatter.dateFormat
 
-import play.api._
-import play.api.data._
 import play.api.libs.json._
 import play.api.mvc._
-import java.io.File
 import java.util.Date
+
 
 private[controllers] case class ResponseData(status: Results.Status, data: JsValue, headers: Seq[(String,String)] = Nil, attachment: Option[AnyRef] = None) {
   def asResult(implicit req: Request[AnyContent]): Result =
@@ -87,6 +84,7 @@ object Api {
       }
     }
   }
+
 
   def statusResponse(status: Boolean, code: Results.Status = Results.Ok) =
     ResponseData(code, JsObject(Seq("SUCCESS" -> JsBoolean(status))))

--- a/app/controllers/AssetWebApi.scala
+++ b/app/controllers/AssetWebApi.scala
@@ -9,6 +9,7 @@ import util.concurrent.BackgroundProcessor
 
 import play.api.mvc._
 import play.api.libs.json._
+import play.api.libs.concurrent.Execution.Implicits._
 
 trait AssetWebApi {
   this: Api with SecureController =>

--- a/app/controllers/actions/asset/ProvisionUtil.scala
+++ b/app/controllers/actions/asset/ProvisionUtil.scala
@@ -246,7 +246,7 @@ trait Provisions extends ProvisionUtil with AssetAction { self: SecureAction =>
     import play.api.Play.current
 
     val ActionDataHolder(asset, pRequest, _, attribs) = adh
-    BackgroundProcessor.send(ProvisionerTest(pRequest)(request)) { res =>
+    BackgroundProcessor.send(ProvisionerTest(pRequest)(request, defaultContext)) { res =>
       processProvisionAction(res) { result =>
         processProvision(result)
       }
@@ -261,7 +261,7 @@ trait Provisions extends ProvisionUtil with AssetAction { self: SecureAction =>
           )
           setAsset(Asset.findById(asset.getId))
         }
-        BackgroundProcessor.send(ProvisionerRun(pRequest)(request)) { res =>
+        BackgroundProcessor.send(ProvisionerRun(pRequest)(request, defaultContext)) { res =>
           processProvisionAction(res) { result =>
             processProvision(result).map { err =>
               tattle("Provisioning failed. Exit code %d\n%s".format(result.commandResult.exitCode,

--- a/app/controllers/actions/resources/IntakeStage1Action.scala
+++ b/app/controllers/actions/resources/IntakeStage1Action.scala
@@ -4,16 +4,19 @@ package resources
 
 import forms._
 import models.Truthy
+import play.api.templates.Html
 import util.IpmiCommand
 import util.concurrent.BackgroundProcessor
 import util.plugins.{IpmiPowerCommand, PowerManagement}
 import util.security.SecuritySpecification
 import collins.power.Identify
-import collins.power.management.{PowerManagement, PowerManagementConfig}
+import collins.power.management.PowerManagement
 import play.api.data.Form
 import play.api.data.Forms._
-import play.api.mvc.AsyncResult
-import com.twitter.util.Await
+import play.api.mvc.{SimpleResult, AsyncResult}
+import scala.concurrent.Future
+import play.api.libs.concurrent.Execution.Implicits._
+
 
 case class IntakeStage1Action(
   assetId: Long,
@@ -54,14 +57,14 @@ case class IntakeStage1Action(
     Redirect(app.routes.Resources.intake(assetId, 1)).flashing("error" -> rd.toString)
   )
 
-  protected def identifyAsset(plugin: PowerManagement) = {
+  protected def identifyAsset(plugin: PowerManagement) : Future[SimpleResult[Html]] = {
     val cmd = IpmiPowerCommand.fromPowerAction(definedAsset, Identify)
-    BackgroundProcessor.send(cmd) { result =>
+    BackgroundProcessor.flatSend(cmd) { result =>
       IpmiCommand.fromResult(result) match {
         case Left(throwable) =>
           verifyIpmiReachable(plugin, throwable.toString)
-        case Right(None) => defaultView
-        case Right(Some(suc)) if suc.isSuccess => defaultView
+        case Right(None) => Future.successful(defaultView)
+        case Right(Some(suc)) if suc.isSuccess => Future.successful(defaultView)
         case Right(Some(error)) if !error.isSuccess =>
           verifyIpmiReachable(plugin, error.toString)
       }
@@ -71,9 +74,9 @@ case class IntakeStage1Action(
   protected def defaultView =
     Status.Ok(views.html.resources.intake(definedAsset)(flash, request))
 
-  protected def verifyIpmiReachable(plugin: PowerManagement, errorString: String) = {
-    val ps = Await.result(plugin.verify(definedAsset))
-    ps match {
+  protected def verifyIpmiReachable(plugin: PowerManagement, errorString: String): Future[SimpleResult[Html]] = {
+    val ps = plugin.verify(definedAsset)
+    ps.map {
       case reachable if reachable.isSuccess =>
         Status.Ok(views.html.help(Help.IpmiError, errorString)(flash, request))
       case unreachable if !unreachable.isSuccess =>

--- a/app/controllers/actors/ActivationProcessor.scala
+++ b/app/controllers/actors/ActivationProcessor.scala
@@ -5,7 +5,7 @@ import scala.concurrent.duration._
 import play.api.mvc.{AnyContent, Request}
 import util.concurrent.BackgroundProcess
 import util.plugins.SoftLayer
-import com.twitter.util.Await
+import scala.concurrent.{Await, Future}
 
 case class ActivationProcessor(slId: Long, userTimeout: Option[FiniteDuration] = None)(implicit req: Request[AnyContent]) extends BackgroundProcess[Boolean] {
   override def defaultTimeout = 60 seconds
@@ -13,7 +13,7 @@ case class ActivationProcessor(slId: Long, userTimeout: Option[FiniteDuration] =
 
   def run(): Boolean = {
     val plugin = SoftLayer.pluginEnabled.get
-    Await.result(plugin.activateServer(slId))
+    Await.result(plugin.activateServer(slId), timeout)
   }
 }
 

--- a/app/controllers/actors/AssetCancelProcessor.scala
+++ b/app/controllers/actors/AssetCancelProcessor.scala
@@ -2,43 +2,51 @@ package controllers
 package actors
 
 import scala.concurrent.duration._
-import models.{Asset, AssetLifecycle, MetaWrapper, Model, Status => AStatus}
+import models.{Asset, AssetLifecycle, MetaWrapper, Status => AStatus}
 import play.api.mvc.{AnyContent, Request}
 import util.plugins.SoftLayer
 import util.concurrent.BackgroundProcess
-import com.twitter.util.Await
+import scala.concurrent.{Await, ExecutionContext}
 
-case class AssetCancelProcessor(tag: String, userTimeout: Option[FiniteDuration] = None)(implicit req: Request[AnyContent])
+case class AssetCancelProcessor(tag: String, userTimeout: Option[FiniteDuration] = None)(implicit req: Request[AnyContent], ec : ExecutionContext)
   extends BackgroundProcess[Either[ResponseData,Long]]
 {
   override def defaultTimeout = 10 seconds
 
   val timeout = userTimeout.getOrElse(defaultTimeout)
+
+  private val noReason : Either[ResponseData,Long] = Left(Api.getErrorMessage("No reason specified for cancellation"))
+
+  private val softlayerDisabled : Either[ResponseData,Long] = Left(Api.getErrorMessage("SoftLayer plugin is not enabled"))
+
+  private val nonSoftlayerAsset : Either[ResponseData,Long] = Left(Api.getErrorMessage("Asset is not a softlayer asset"))
+
+  private val cancellationError : Either[ResponseData,Long] = Left(Api.getErrorMessage("There was an error cancelling this server"))
+
   def run(): Either[ResponseData,Long] = {
-    req.body.asFormUrlEncoded.flatMap(_.get("reason")).flatMap(_.headOption).map(_.trim).filter(_.size > 0).map { _reason =>
-      val reason = _reason.trim
+
+    val reasonOpt = req.body.asFormUrlEncoded.flatMap(_.get("reason")).flatMap(_.headOption).map(_.trim).filter(_.size > 0)
+
+    reasonOpt.fold(noReason){ r =>
+      val reason = r.trim
       Api.withAssetFromTag(tag) { asset =>
-        SoftLayer.pluginEnabled.map { plugin =>
-          plugin.softLayerId(asset) match {
-            case None =>
-              Left(Api.getErrorMessage("Asset is not a softlayer asset"))
-            case Some(n) =>
-              Await.result(plugin.cancelServer(n, reason)) match {
-                case 0L =>
-                  Left(Api.getErrorMessage("There was an error cancelling this server"))
-                case ticketId =>
-                  Asset.inTransaction {
-                    MetaWrapper.createMeta(asset, Map("CANCEL_TICKET" -> ticketId.toString))
-                    AssetLifecycle.updateAssetStatus(asset, AStatus.Cancelled, None, reason)
-                  }
-                  Await.result(plugin.setNote(n, "Cancelled: %s".format(reason)))
-                  Right(ticketId)
-              }
+        SoftLayer.pluginEnabled.fold(softlayerDisabled){ plugin =>
+
+          plugin.softLayerId(asset).fold(nonSoftlayerAsset) { n =>
+
+            Await.result(plugin.cancelServer(n, reason), timeout) match  {
+              case 0L => cancellationError
+              case ticketId =>
+                Asset.inTransaction {
+                  MetaWrapper.createMeta(asset, Map("CANCEL_TICKET" -> ticketId.toString))
+                  AssetLifecycle.updateAssetStatus(asset, AStatus.Cancelled, None, reason)
+                }
+                Await.result(plugin.setNote(n, "Cancelled: %s".format(reason)), timeout)
+                Right(ticketId)
+            }
           }
-        }.getOrElse {
-          Left(Api.getErrorMessage("SoftLayer plugin is not enabled"))
         }
       }
-    }.getOrElse(Left(Api.getErrorMessage("No reason specified for cancellation")))
+    }
   }
 }

--- a/app/controllers/actors/TestProcessor.scala
+++ b/app/controllers/actors/TestProcessor.scala
@@ -3,8 +3,6 @@ package actors
 
 import scala.concurrent.duration._
 import util.concurrent.BackgroundProcess
-import com.twitter.util.Future
-import com.twitter.util.Await
 
 case class TestProcessor(sleepMs: Long, userTimeout: Option[FiniteDuration] = None)
   extends BackgroundProcess[Boolean]
@@ -13,11 +11,9 @@ case class TestProcessor(sleepMs: Long, userTimeout: Option[FiniteDuration] = No
   val timeout = userTimeout.getOrElse(defaultTimeout)
 
   def run(): Boolean = {
-    Await.result(Future {
       println("Sleeping for %d millis".format(sleepMs))
       Thread.sleep(sleepMs)
       println("Done sleeping for %d millins".format(sleepMs))
-    })
-    true
+      true
   }
 }

--- a/app/util/IpmiCommand.scala
+++ b/app/util/IpmiCommand.scala
@@ -1,12 +1,12 @@
 package util
 
 import config.AppConfig
-import models.{Asset, IpmiInfo}
+import models.IpmiInfo
 import concurrent.BackgroundProcess
 import collins.shell.CommandResult
 
 import scala.concurrent.duration.Duration
-import play.api.{Logger, Mode}
+import play.api.Logger
 import java.util.concurrent.TimeUnit
 import scala.collection.mutable.StringBuilder
 import scala.sys.process._

--- a/app/util/plugins/IpmiPowerManagement.scala
+++ b/app/util/plugins/IpmiPowerManagement.scala
@@ -7,16 +7,16 @@ import play.api.{Application, Plugin}
 
 import collins.power._
 import collins.power.management._
-import com.twitter.util.{Future, FuturePool}
-import java.util.concurrent.{Executors, TimeUnit}
+import java.util.concurrent.Executors
+import scala.concurrent.{Future, ExecutionContext}
 import scala.concurrent.duration._
 
 case class IpmiPowerCommand(
   override val ipmiCommand: String,
   override val ipmiInfo: IpmiInfo,
   override val interval: Duration = 60.seconds,
-  val verify: Boolean = false,
-  val userTimeout: Option[FiniteDuration] = None)
+  verify: Boolean = false,
+  userTimeout: Option[FiniteDuration] = None)
 extends IpmiCommand {
   override def defaultTimeout = PowerManagementConfig.timeoutMs.milliseconds
   override val timeout = userTimeout.getOrElse(defaultTimeout)
@@ -47,8 +47,10 @@ object IpmiPowerCommand {
 }
 
 class IpmiPowerManagement(app: Application) extends Plugin with PowerManagement {
+
   protected[this] val executor = Executors.newCachedThreadPool()
-  protected[this] val pool = FuturePool(executor)
+
+  protected[this] implicit val ec = ExecutionContext.fromExecutor(executor)
 
   override def enabled: Boolean = {
     PowerManagementConfig.pluginInitialize(app.configuration)
@@ -75,14 +77,15 @@ class IpmiPowerManagement(app: Application) extends Plugin with PowerManagement 
   def identify(e: Asset): PowerStatus = run(e, Identify)
   def verify(e: Asset): PowerStatus = run(e, Verify)
 
-  protected[this] def run(e: Asset, action: PowerAction): PowerStatus = pool {
-    IpmiPowerCommand.fromPowerAction(getAsset(e), action).run() match {
-      case None => Failure("powermanagement not enabled or available in environment")
-      case Some(status) => status.isSuccess match {
-        case true => Success(status.stdout)
-        case false => Failure(status.stderr.getOrElse("Error running command for %s".format(action)))
+  protected[this] def run(e: Asset, action: PowerAction): PowerStatus =
+    Future{
+      IpmiPowerCommand.fromPowerAction(getAsset(e), action).run() match {
+        case None => Failure("powermanagement not enabled or available in environment")
+        case Some(status) => status.isSuccess match {
+          case true => Success(status.stdout)
+          case false => Failure(status.stderr.getOrElse("Error running command for %s".format(action)))
+        }
       }
-    }
   }
   protected[this] def getAsset(e: Asset): Asset = Asset.findByTag(e.tag) match {
     case Some(a) => a


### PR DESCRIPTION
removed all Awaits except for one that is used by
MultiCollins/BackgroundProcess

This is one PR which removes Twitter futures and uses Scala Futures/timeouts.  I removed all timeouts that were not connected to multi collins(not used), and for background processing(because changing BackgroundProcess to being asynchronous is not a trivial task).

I have another branch off of this one which removes the finagle library entirely.  I will pr that one separately as I wanted to keep this one focused.