### PR TITLE
Externalize akka configuration for background process and solr

### DIFF
--- a/app/collins/solr/SolrPlugin.scala
+++ b/app/collins/solr/SolrPlugin.scala
@@ -49,10 +49,6 @@ class SolrPlugin(app: Application) extends Plugin {
   val assetSerializer = new AssetSerializer
   val assetLogSerializer = new AssetLogSerializer
 
-  //this must be lazy so it gets called after the system exists
-  lazy val updater = Akka.system.actorOf(Props[AssetSolrUpdater], name = "solr_asset_updater")
-  lazy val logUpdater = Akka.system.actorOf(Props[AssetLogSolrUpdater], name = "solr_asset_log_updater")
-
   override def onStart() {
     if (enabled) {
       System.setProperty("org.apache.commons.logging.Log", "org.apache.commons.logging.impl.SimpleLog");
@@ -87,6 +83,9 @@ class SolrPlugin(app: Application) extends Plugin {
    * properly reindex the updated asset in Solr
    */
   private def initializeCallbacks() {
+    val updater = Akka.system.actorOf(Props[AssetSolrUpdater], name = "solr_asset_updater")
+    val logUpdater = Akka.system.actorOf(Props[AssetLogSolrUpdater], name = "solr_asset_log_updater")
+
     val callback = SolrAssetCallbackHandler(server, updater)
     Callback.on("asset_update", callback)
     Callback.on("asset_create", callback)

--- a/app/util/concurrent/BackgroundProcessor.scala
+++ b/app/util/concurrent/BackgroundProcessor.scala
@@ -26,14 +26,7 @@ case class SexyTimeoutException(timeout: Duration) extends Exception("Command ti
 object BackgroundProcessor {
   import play.api.Play.current
 
-  lazy val ref = {
-    val routees = (0 until 128).map { _ =>
-      Akka.system.actorOf(Props[BackgroundProcessorActor])
-    }
-    Akka.system.actorOf(
-      Props[BackgroundProcessorActor].withRouter(RoundRobinRouter(routees))
-    )
-  }
+  lazy val ref = Akka.system.actorOf(Props[BackgroundProcessorActor], name = "background-processor")
 
   type SendType[T] = (Option[Throwable], Option[T])
 

--- a/conf/dev_base.conf
+++ b/conf/dev_base.conf
@@ -66,7 +66,7 @@ nodeclassifier.sortKeys = [SL_RACK_POSITION, SL_RACK] #ordered from least signif
 powerconfiguration.unitsRequired=2
 
 callbacks.registry {
-  
+
   nowProvisioned {
     on = "asset_update"
 
@@ -252,4 +252,58 @@ solr {
   useEmbeddedServer = true
   externalUrl="http://localhost:8983/solr"
   embeddedSolrHome = "conf/solr/"
+}
+
+# Thread pool Configuration
+# ~~~~~
+
+# https://www.playframework.com/documentation/2.2.x/ThreadPools
+# these options would be the default for current collins nodes
+# if unspecified, asset 007117 has 24 vcpus
+
+# internal thread pool for play framework threads
+internal-threadpool-size = 24
+
+# play default thread pool
+# Accessible under play-akka.actor.default-dispatcher
+play {
+  akka {
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+          parallelism-max = 24
+        }
+      }
+    }
+  }
+}
+
+# Akka thread pool, used internally by Collins
+# Accessible under application-akka.actor.default-dispatcher
+akka {
+  actor {
+    default-dispatcher = {
+      fork-join-executor {
+        parallelism-factor = 1.0
+        parallelism-max = 24
+      }
+    }
+
+    deployment = {
+      /background-processor = {
+        dispatcher = default-dispatcher
+        router = round-robin
+        nr-of-instances = 128
+      }
+
+      /solr_asset_updater = {
+        dispatcher = default-dispatcher
+      }
+
+      /solr_asset_log_updater = {
+        dispatcher = default-dispatcher
+      }
+    }
+  }
 }

--- a/conf/dev_base.conf
+++ b/conf/dev_base.conf
@@ -258,8 +258,7 @@ solr {
 # ~~~~~
 
 # https://www.playframework.com/documentation/2.2.x/ThreadPools
-# these options would be the default for current collins nodes
-# if unspecified, asset 007117 has 24 vcpus
+# these are the default options for a 24 vcpu host
 
 # internal thread pool for play framework threads
 internal-threadpool-size = 24

--- a/conf/docker/production.conf
+++ b/conf/docker/production.conf
@@ -62,7 +62,7 @@ nodeclassifier.sortKeys = [SL_RACK_POSITION, SL_RACK] #ordered from least signif
 powerconfiguration.unitsRequired=2
 
 callbacks.registry {
-  
+
   nowProvisioned {
     on = "asset_update"
 
@@ -248,5 +248,32 @@ solr {
   embeddedSolrHome = "conf/solr/"
 }
 
-include "database.conf"
+# Akka thread pool, used internally by Collins
+# Accessible under application-akka.actor.default-dispatcher
+akka {
+  actor {
+    default-dispatcher = {
+      fork-join-executor {
+        parallelism-factor = 1.0
+      }
+    }
 
+    deployment = {
+      /background-processor = {
+        dispatcher = default-dispatcher
+        router = round-robin
+        nr-of-instances = 128
+      }
+
+      /solr_asset_updater = {
+        dispatcher = default-dispatcher
+      }
+
+      /solr_asset_log_updater = {
+        dispatcher = default-dispatcher
+      }
+    }
+  }
+}
+
+include "database.conf"

--- a/conf/docker/production.conf
+++ b/conf/docker/production.conf
@@ -248,6 +248,25 @@ solr {
   embeddedSolrHome = "conf/solr/"
 }
 
+# Thread pool Configuration
+# ~~~~~
+
+# https://www.playframework.com/documentation/2.2.x/ThreadPools
+
+# play default thread pool
+# Accessible under play-akka.actor.default-dispatcher
+play {
+  akka {
+    actor {
+      default-dispatcher = {
+        fork-join-executor {
+          parallelism-factor = 1.0
+        }
+      }
+    }
+  }
+}
+
 # Akka thread pool, used internally by Collins
 # Accessible under application-akka.actor.default-dispatcher
 akka {


### PR DESCRIPTION
Summary:
Externalizing akka configuration will enable updates to akka without
requiring code changes

Apache Bench - GET - All assets

➜  ~  ab -n 50000 -c 100 -A blake:admin:first http://localhost:9000/api/assets
This is ApacheBench, Version 2.3 <$Revision: 655654 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 5000 requests
Completed 10000 requests
Completed 15000 requests
Completed 20000 requests
Completed 25000 requests
Completed 30000 requests
Completed 35000 requests
Completed 40000 requests
Completed 45000 requests
Completed 50000 requests
Finished 50000 requests

Server Software:
Server Hostname:        localhost
Server Port:            9000

Document Path:          /api/assets
Document Length:        55627 bytes

Concurrency Level:      100
Time taken for tests:   222.486 seconds
Complete requests:      50000
Failed requests:        0
Write errors:           0
Total transferred:      2792700000 bytes
HTML transferred:       2781350000 bytes
Requests per second:    224.73 [#/sec] (mean)
Time per request:       444.972 [ms] (mean)
Time per request:       4.450 [ms] (mean, across all concurrent requests)
Transfer rate:          12258.05 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   3.2      0     208
Processing:    19  444 309.7    419    2945
Waiting:       18  444 309.7    418    2945
Total:         19  445 309.8    419    2945

Percentage of the requests served within a certain time (ms)
  50%    419
  66%    534
  75%    606
  80%    661
  90%    855
  95%   1022
  98%   1219
  99%   1395
 100%   2945 (longest request)

@nsauro @byxorna @DanSimon @Primer42 