### PR TITLE
Enable container based builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# enable container based builds
+# http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
+sudo: false
+
 language: scala
 # according to http://docs.travis-ci.com/user/ci-environment/#CI-environment-OS
 # every travis CI has a version of ruby installed


### PR DESCRIPTION
Speeds up our builds by a few minutes, and makes them start sooner.
http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
@maddalab @byxorna @defect @roymarantz 