### PR TITLE
[WIP] Remove the use of arbitrary dispatcher and use play built in actor system

### DIFF
--- a/app/collins/callbacks/CallbackManagerPlugin.scala
+++ b/app/collins/callbacks/CallbackManagerPlugin.scala
@@ -4,7 +4,7 @@ package callbacks
 import java.beans.{PropertyChangeEvent, PropertyChangeListener, PropertyChangeSupport}
 import play.api.{Application, Configuration, Logger, Plugin}
 import play.api.Play.current
-import play.api.libs.concurrent._
+import play.api.libs.concurrent.Akka
 import akka.actor.Props
 
 class CallbackManagerPlugin(app: Application) extends Plugin with AsyncCallbackManager {

--- a/app/collins/provisioning/Provisioner.scala
+++ b/app/collins/provisioning/Provisioner.scala
@@ -2,15 +2,14 @@ package collins.provisioning
 
 import models.Asset
 import play.api.Logger
-import scala.concurrent.Future
 import collins.shell.CommandResult
 
 trait Provisioner {
   protected[this] val logger = Logger(getClass)
   def profiles: Set[ProvisionerProfile]
   def canProvision(asset: Asset): Boolean
-  def provision(request: ProvisionerRequest): Future[CommandResult]
-  def test(request: ProvisionerRequest): Future[CommandResult]
+  def provision(request: ProvisionerRequest): CommandResult
+  def test(request: ProvisionerRequest): CommandResult
   def profile(id: String): Option[ProvisionerProfile] = {
     profiles.find(_.identifier == id)
   }

--- a/app/collins/provisioning/ProvisionerPlugin.scala
+++ b/app/collins/provisioning/ProvisionerPlugin.scala
@@ -4,9 +4,8 @@ import collins.cache.ConfigCache
 import collins.shell.{Command, CommandResult}
 import models.Asset
 import play.api.{Application, Plugin}
-import scala.concurrent.{ExecutionContext, Future, future}
-import java.util.concurrent.Executors
-import play.libs.Akka
+import play.api.libs.concurrent.Akka
+import play.api.Play.current
 
 
 class ProvisionerPlugin(app: Application) extends Plugin with Provisioner {
@@ -42,30 +41,24 @@ class ProvisionerPlugin(app: Application) extends Plugin with Provisioner {
   }
 
   // overrides ProvisionerInterface.provision
-  override def provision(request: ProvisionerRequest): Future[CommandResult] = {
-    implicit val ec = Akka.system.dispatchers.lookup("default-dispatcher")
-    future[CommandResult] {
-      val result = runCommand(command(request, ProvisionerConfig.command))
-      if (result.exitCode != 0) {
-        logger.warn("Command executed: %s".format(command(request, ProvisionerConfig.command)))
-        logger.warn("Command code: %d, output %s".format(result.exitCode, result.stdout))
-      }
-      result
+  override def provision(request: ProvisionerRequest): CommandResult = {
+    val result = runCommand(command(request, ProvisionerConfig.command))
+    if (result.exitCode != 0) {
+      logger.warn("Command executed: %s".format(command(request, ProvisionerConfig.command)))
+      logger.warn("Command code: %d, output %s".format(result.exitCode, result.stdout))
     }
+    result
   }
 
-  override def test(request: ProvisionerRequest): Future[CommandResult] = {
-    implicit val ec = Akka.system.dispatchers.lookup("background-dispatcher")
+  override def test(request: ProvisionerRequest): CommandResult = {
     val cmd = try command(request, ProvisionerConfig.checkCommand) catch {
-      case _: Throwable => return Future(CommandResult(0,"No check command specified"))
+      case _: Throwable => return CommandResult(0,"No check command specified")
     }
-    future[CommandResult] {
-      val result = runCommand(cmd)
-      if (result.exitCode != 0) {
-        logger.warn("Command code: %d, output %s".format(result.exitCode, result.stdout))
-      }
-      result
+    val result = runCommand(cmd)
+    if (result.exitCode != 0) {
+      logger.warn("Command code: %d, output %s".format(result.exitCode, result.stdout))
     }
+    result
   }
 
   protected def runCommand(cmd: String): CommandResult = {

--- a/app/collins/solr/SolrPlugin.scala
+++ b/app/collins/solr/SolrPlugin.scala
@@ -17,9 +17,9 @@ import org.apache.solr.core.CoreContainer
 import org.apache.solr.client.solrj.impl.{HttpSolrServer, XMLResponseParser}
 
 import play.api.{Application, Logger, Play, PlayException, Plugin}
-import play.api.libs.concurrent._
-import play.api.libs.concurrent.Akka._
+import play.api.libs.concurrent.Akka
 import play.api.Play.current
+import akka.actor.Props
 
 import util.AttributeResolver
 import util.plugins.Callback

--- a/app/controllers/actions/asset/ProvisionUtil.scala
+++ b/app/controllers/actions/asset/ProvisionUtil.scala
@@ -246,7 +246,7 @@ trait Provisions extends ProvisionUtil with AssetAction { self: SecureAction =>
     import play.api.Play.current
 
     val ActionDataHolder(asset, pRequest, _, attribs) = adh
-    BackgroundProcessor.send(ProvisionerTest(pRequest)(request, defaultContext)) { res =>
+    BackgroundProcessor.send(ProvisionerTest(pRequest)) { res =>
       processProvisionAction(res) { result =>
         processProvision(result)
       }
@@ -261,7 +261,7 @@ trait Provisions extends ProvisionUtil with AssetAction { self: SecureAction =>
           )
           setAsset(Asset.findById(asset.getId))
         }
-        BackgroundProcessor.send(ProvisionerRun(pRequest)(request, defaultContext)) { res =>
+        BackgroundProcessor.send(ProvisionerRun(pRequest)) { res =>
           processProvisionAction(res) { result =>
             processProvision(result).map { err =>
               tattle("Provisioning failed. Exit code %d\n%s".format(result.commandResult.exitCode,

--- a/app/controllers/actors/ProvisionerProcessor.scala
+++ b/app/controllers/actors/ProvisionerProcessor.scala
@@ -1,11 +1,9 @@
 package controllers
 package actors
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.FiniteDuration
 import collins.provisioning.ProvisionerRequest
 import collins.shell.CommandResult
-import scala.concurrent.{ExecutionContext, Future, Await}
-import play.api.mvc.{AnyContent, Request}
 import util.concurrent.BackgroundProcess
 import util.plugins.Provisioner
 
@@ -22,33 +20,29 @@ object ProvisionerStatus {
 
 case class ProvisionerResult(status: ProvisionerStatus, commandResult: CommandResult)
 
-case class ProvisionerTest(request: ProvisionerRequest, userTimeout: Option[FiniteDuration] = None)(implicit req: Request[AnyContent], ec : ExecutionContext) extends BackgroundProcess[ProvisionerResult]
+case class ProvisionerTest(request: ProvisionerRequest, userTimeout: Option[FiniteDuration] = None) extends BackgroundProcess[ProvisionerResult]
 {
-  override def defaultTimeout = 90 seconds
   val timeout = userTimeout.getOrElse(defaultTimeout)
-
+  
   def run(): ProvisionerResult = {
     Provisioner.pluginEnabled { plugin =>
-      Await.result(plugin.test(request).map { res =>
-        if (res.exitCode == 0)
-          ProvisionerResult(ProvisionerStatus.TestSucceeded, res)
-        else
-          ProvisionerResult(ProvisionerStatus.TestFailed, res)
-      }, timeout)
+      val res = plugin.test(request)
+      if (res.exitCode == 0)
+        ProvisionerResult(ProvisionerStatus.TestSucceeded, res)
+      else
+        ProvisionerResult(ProvisionerStatus.TestFailed, res)
     }.getOrElse(ProvisionerResult(ProvisionerStatus.PluginDisabled, CommandResult(-2, "Provisioner plugin not enabled")))
   }
 }
 
-case class ProvisionerRun(request: ProvisionerRequest, userTimeout: Option[FiniteDuration] = None)(implicit req: Request[AnyContent], ec : ExecutionContext) extends BackgroundProcess[ProvisionerResult]
+case class ProvisionerRun(request: ProvisionerRequest, userTimeout: Option[FiniteDuration] = None) extends BackgroundProcess[ProvisionerResult]
 {
-  override def defaultTimeout = 90 seconds
   val timeout = userTimeout.getOrElse(defaultTimeout)
 
   def run(): ProvisionerResult = {
-    Provisioner.pluginEnabled{ plugin =>
-      Await.result(plugin.provision(request).map { cmd =>
-        ProvisionerResult(ProvisionerStatus.CommandExecuted, cmd)
-      }, timeout)
-      }
+    Provisioner.pluginEnabled { plugin =>
+	  val cmd = plugin.provision(request)
+	  ProvisionerResult(ProvisionerStatus.CommandExecuted, cmd)
     }.getOrElse(ProvisionerResult(ProvisionerStatus.PluginDisabled, CommandResult(-2, "Provisioner plugin not enabled")))
+  }
 }

--- a/app/util/IpmiCommand.scala
+++ b/app/util/IpmiCommand.scala
@@ -72,7 +72,7 @@ abstract class IpmiCommand extends BackgroundProcess[Option[CommandResult]] {
     Some(cr)
   }
 
-  override protected def defaultTimeout: Duration = Duration(2, TimeUnit.MILLISECONDS)
+  override protected def defaultTimeout = Duration(2, TimeUnit.MILLISECONDS)
 
   protected def substitute(cmd: String): String = {
     cmd.replace("<host>", address)

--- a/app/util/concurrent/BackgroundProcess.scala
+++ b/app/util/concurrent/BackgroundProcess.scala
@@ -8,5 +8,5 @@ trait BackgroundProcess[T] {
   val timeout: FiniteDuration
   def run(): T
 
-  protected def defaultTimeout: Duration = Duration(ConcurrencyConfig.timeoutMs, TimeUnit.MILLISECONDS)
+  protected def defaultTimeout = Duration(ConcurrencyConfig.timeoutMs, TimeUnit.MILLISECONDS)
 }

--- a/app/util/concurrent/BackgroundProcessor.scala
+++ b/app/util/concurrent/BackgroundProcessor.scala
@@ -7,9 +7,10 @@ import akka.pattern.ask
 import akka.routing.RoundRobinRouter
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
-import play.api.libs.concurrent._
+import play.api.libs.concurrent.Akka
 import java.util.concurrent.TimeoutException
 import play.api.libs.concurrent.Execution.Implicits._
+import akka.actor.Props
 
 
 class BackgroundProcessorActor extends Actor {

--- a/app/util/concurrent/ConcurrencyConfig.scala
+++ b/app/util/concurrent/ConcurrencyConfig.scala
@@ -7,12 +7,9 @@ object ConcurrencyConfig extends Configurable {
   override val namespace = "concurrency"
   override val referenceConfigFilename = "concurrency_reference.conf"
 
-  val DefaultActorCount = Runtime.getRuntime().availableProcessors()*2
-  lazy val ActorCount = getInt("actorCount").filter(_ > 0).getOrElse(DefaultActorCount)
   def timeoutMs = getMilliseconds("timeout").getOrElse(2000L)
 
   override protected def validateConfig() {
-    ActorCount
     timeoutMs
   }
 }

--- a/conf/reference/concurrency_reference.conf
+++ b/conf/reference/concurrency_reference.conf
@@ -1,7 +1,4 @@
 concurrency {
-  # actorCount defaults to number of CPUs * 2
-  actorCount = 0
-
-  # timeout
+  # timeout for background processes
   timeout = 2 seconds
 }


### PR DESCRIPTION
Summary:
After our fumbles with ipmi errors, reviewed the implementation and use
of dispatcher. This refactoring makes proper use of plays actor system.
We can document the actors when they are used. The actors can be configured
using plays configuration (same as the previous attempt). Collins
now only requires the default-dispatcher on account of using
`Execution.Implicits` at a few places. The remainder of Collins relies on
actors

WIP - Need additional testing, basic smoke tests complete and succeed

@byxorna @defect @nsauro @DanSimon @Primer42 