### PR TITLE
Adding intake and display of serial number from lshw

### DIFF
--- a/app/models/AssetMeta.scala
+++ b/app/models/AssetMeta.scala
@@ -194,9 +194,10 @@ object AssetMeta extends Schema with AnormAdapter[AssetMeta] {
     val BaseDescription = AssetMeta.findOrCreateFromName("BASE_DESCRIPTION")
     val BaseProduct = AssetMeta.findOrCreateFromName("BASE_PRODUCT")
     val BaseVendor = AssetMeta.findOrCreateFromName("BASE_VENDOR")
+    val BaseSerial = AssetMeta.findOrCreateFromName("BASE_SERIAL")
 
     def getValues(): Seq[AssetMeta] = {
-      Seq(BaseDescription,BaseProduct,BaseVendor)
+      Seq(BaseDescription,BaseProduct,BaseVendor,BaseSerial)
     }
 
 

--- a/app/models/LshwHelper.scala
+++ b/app/models/LshwHelper.scala
@@ -206,7 +206,8 @@ object LshwHelper extends CommonHelper[LshwRepresentation] {
       val baseDescription = amfinder(seq, BaseDescription, _.toString, "")
       val baseProduct = amfinder(seq, BaseProduct, _.toString, "")
       val baseVendor = amfinder(seq, BaseVendor, _.toString, "")
-      Seq(ServerBase(baseDescription, baseProduct, baseVendor))
+      val baseSerial = amfinder(seq, BaseSerial, _.toString, "")
+      Seq(ServerBase(baseDescription, baseProduct, baseVendor, baseSerial))
     }.getOrElse(Nil)
 
     val filteredMeta = meta.map { case(groupId, metaSeq) =>
@@ -224,7 +225,8 @@ object LshwHelper extends CommonHelper[LshwRepresentation] {
     Seq(
       AssetMetaValue(asset, BaseDescription.id, base.description),
       AssetMetaValue(asset, BaseProduct.id, base.product),
-      AssetMetaValue(asset, BaseVendor.id, base.vendor)
+      AssetMetaValue(asset, BaseVendor.id, base.vendor),
+      AssetMetaValue(asset, BaseSerial.id, base.serial)
     )
   }
 

--- a/app/models/lshw/ServerBase.scala
+++ b/app/models/lshw/ServerBase.scala
@@ -8,21 +8,23 @@ object ServerBase {
     override def reads(json: JsValue) = JsSuccess(ServerBase(
       (json \ "DESCRIPTION").as[String],
       (json \ "PRODUCT").as[String],
-      (json \ "VENDOR").as[String]
+      (json \ "VENDOR").as[String],
+      (json \ "SERIAL").as[String]
     ))
     override def writes(serverbase: ServerBase) = JsObject(Seq(
       "DESCRIPTION" -> toJson(serverbase.description),
       "PRODUCT" -> toJson(serverbase.product),
-      "VENDOR" -> toJson(serverbase.vendor)
+      "VENDOR" -> toJson(serverbase.vendor),
+      "SERIAL" -> toJson(serverbase.serial)
     ))
   }
 }
 
 case class ServerBase(
-  description: String = "", product: String = "", vendor: String = ""
+  description: String = "", product: String = "", vendor: String = "", serial: String = ""
 ) extends LshwAsset {
   import ServerBase._
   override def toJsValue() = Json.toJson(this)
 
-  def isEmpty(): Boolean = description.isEmpty && product.isEmpty && vendor.isEmpty
+  def isEmpty(): Boolean = description.isEmpty && product.isEmpty && vendor.isEmpty && serial.isEmpty
 }

--- a/app/util/parsers/LshwParser.scala
+++ b/app/util/parsers/LshwParser.scala
@@ -179,13 +179,15 @@ class LshwParser(txt: String) extends CommonParser[LshwRepresentation](txt) {
     // the correct element
     if ((elem \ "@class" text).toString == "system") {
       val asset = getAsset(elem)
-      ServerBase(asset.description, asset.product, asset.vendor)
+      val serial = (elem \ "serial" text)
+      ServerBase(asset.description, asset.product, asset.vendor, serial)
     }
     // To spice things up, sometimes we get <list>$everything</list>
     // instead of just $everything
     else if (((elem \ "node") \ "@class" text) == "system")  {
       val asset = getAsset(elem \ "node")
-      ServerBase(asset.description, asset.product, asset.vendor)
+      val serial = (elem \ "serial" text)
+      ServerBase(asset.description, asset.product, asset.vendor, serial)
     }
     else {
       throw MalformedAttributeException("Expected root class=system node attribute")

--- a/app/views/asset/show_hwdetails.scala.html
+++ b/app/views/asset/show_hwdetails.scala.html
@@ -6,142 +6,136 @@
 <div class="tab-pane" id="hardware-details">
   @if(aa.lshw.cpuCount > 0) {
     @if(!aa.lshw.base.isEmpty) {
-    <section class="sectional">
-    <h3>Server Base <small>Server information reported by LSHW</small></h3>
-      <table class="table table-hover table-condensed">
-        <thead>
-          <tr>
-            <th>Field</th><th>Value</th>
-          </tr>
-        </thead>
-        <tbody>
-          <!-- Description is not displayed because it is rarely interesting (usually something like "system") -->
-          <!--
-          <tr>
-            <td>Description</td><td>@aa.lshw.base.description</td>
-          </tr>
-          -->
-          <tr>
-            <td>Product</td><td>@aa.lshw.base.product</td>
-          </tr>
-          <tr>
-            <td>Vendor</td><td>@aa.lshw.base.vendor</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
+    <h4>Server Base <small>Collected information about the server itself</small></h4>
+    <table class="table table-bordered table-hover table-condensed">
+      <thead>
+        <tr>
+          <th>Field</th><th>Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- Description is not displayed because it is rarely interesting (usually something like "system") -->
+        <!--
+        <tr>
+          <td>Description</td><td>@aa.lshw.base.description</td>
+        </tr>
+        -->
+        <tr>
+          <td>Product</td><td>@aa.lshw.base.product</td>
+        </tr>
+        <tr>
+          <td>Vendor</td><td>@aa.lshw.base.vendor</td>
+        </tr>
+
+        <tr>
+            <td>Serial</td><td>@aa.lshw.base.serial</td>
+        </tr>
+      </tbody>
+    </table>
     }
 
-  <section class="sectional">
-    <h3>Network Interfaces <small>NIC information reported by LSHW</small></h3>
-    <table class="table table-hover table-condensed">
-      <thead>
+  <h4>Network Interfaces <small>Collected NIC Information</small></h4>
+  <table class="table table-bordered table-hover table-condensed">
+    <thead>
+      <tr>
+        <th>Id</th><th>Speed</th><th>MAC Address</th><th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+    @aa.lshw.nics.zipWithIndex.map { case(nic,id) =>
+      <tr>
+        <th>@id</th>
+        <td>@{nic.speed.toHuman}/s</td>
+        <td>@nic.macAddress</td>
+        <td>@nic.description</td>
+      </tr>
+    }
+    </tbody>
+  </table>
+
+  <h4>CPU <small>Collected CPU Information</small></h4>
+  <table class="table table-bordered table-hover table-condensed">
+    <thead>
+      <tr>
+        <th>Id</th><th>Cores</th><th>Threads</th><th>Speed</th><th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+    @aa.lshw.cpus.zipWithIndex.map { case(cpu,id) =>
+      <tr>
+        <th>@id</th>
+        <td>@cpu.cores</td>
+        <td>@cpu.threads</td>
+        <td>@cpu.speedGhz</td>
+        <td>@cpu.description</td> <!-- vendor? -->
+      </tr>
+    }
+    </tbody>
+  </table>
+
+  <h4>Memory <small>Collected Memory Information</small></h4>
+  <table class="table table-bordered table-hover table-condensed">
+    <thead>
+      <tr>
+        <th>Bank Id</th><th>Size</th><th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+    @aa.lshw.memory.map { mem =>
+      <tr>
+        <th>@mem.bank</th>
+        <td>@mem.size.toHuman</td>
+        <td>@mem.description</td>
+      </tr>
+    }
+    </tbody>
+  </table>
+
+  <h4>Disks <small>Collected Disk Information</small></h4>
+  <table class="table table-bordered table-hover table-condensed">
+    <thead>
+      <tr>
+        <th>Id</th><th>Size</th><th>Type</th><th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+    @aa.lshw.disks.zipWithIndex.map { case(disk,id) =>
+      <tr>
+        <th>@id</th>
+        <td>@disk.size.toHuman</td>
+        <td>@disk.diskType</td>
+        <td>@disk.description</td>
+      </tr>
+    }
+    </tbody>
+  </table>
+
+  <h4>Power <small>Submitted Power Information</small></h4>
+  <table class="table table-bordered table-hover table-condensed">
+    <thead>
+      <tr>
+        <th>Unit ID</th><th>Priority</th><th>Label</th><th>Type</th><th>Value</th><th>API Key</th>
+      </tr>
+    </thead>
+    <tbody>
+      @ListHelper.getPowerComponentsInOrder(aa.power).map { component =>
         <tr>
-          <th>Id</th><th>Speed</th><th>MAC Address</th><th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-      @aa.lshw.nics.zipWithIndex.map { case(nic,id) =>
-        <tr>
-          <th>@id</th>
-          <td>@{nic.speed.toHuman}/s</td>
-          <td>@nic.macAddress</td>
-          <td>@nic.description</td>
+          <td>@component.id</td>
+          <td>@component.position</td>
+          <td>@component.label</td>
+          <td>@component.identifier</td>
+          <td>@TagDecorator.decorate(component.identifier, component.value.getOrElse("Unspecified"))</td>
+          <td>@component.key</td>
         </tr>
       }
-      </tbody>
-    </table>
-  </section>
-
-  <section class="sectional">
-    <h3>Processors <small>CPUs reported by LSHW</small></h3>
-    <table class="table table-hover table-condensed">
-      <thead>
-        <tr>
-          <th>Id</th><th>Cores</th><th>Threads</th><th>Speed</th><th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-      @aa.lshw.cpus.zipWithIndex.map { case(cpu,id) =>
-        <tr>
-          <th>@id</th>
-          <td>@cpu.cores</td>
-          <td>@cpu.threads</td>
-          <td>@cpu.speedGhz</td>
-          <td>@cpu.description</td> <!-- vendor? -->
-        </tr>
-      }
-      </tbody>
-    </table>
-  </section>
-
-  <section class="sectional">
-    <h3>Memory <small>Memory reported by LSHW</small></h3>
-    <table class="table table-hover table-condensed">
-      <thead>
-        <tr>
-          <th>Bank Id</th><th>Size</th><th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-      @aa.lshw.memory.map { mem =>
-        <tr>
-          <th>@mem.bank</th>
-          <td>@mem.size.toHuman</td>
-          <td>@mem.description</td>
-        </tr>
-      }
-      </tbody>
-    </table>
-  </section>
-
-  <section class="sectional">
-    <h3>Disks <small>Block storage devices reported by LSHW</small></h3>
-    <table class="table table-hover table-condensed">
-      <thead>
-        <tr>
-          <th>Id</th><th>Size</th><th>Type</th><th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-      @aa.lshw.disks.zipWithIndex.map { case(disk,id) =>
-        <tr>
-          <th>@id</th>
-          <td>@disk.size.toHuman</td>
-          <td>@disk.diskType</td>
-          <td>@disk.description</td>
-        </tr>
-      }
-      </tbody>
-    </table>
-  </section>
-
-  <section class="sectional">
-    <h3>Power <small>Power supply information reported by LSHW</small></h3>
-    <table class="table table-hover table-condensed">
-      <thead>
-        <tr>
-          <th>Unit ID</th><th>Priority</th><th>Label</th><th>Type</th><th>Value</th><th>API Key</th>
-        </tr>
-      </thead>
-      <tbody>
-        @ListHelper.getPowerComponentsInOrder(aa.power).map { component =>
-          <tr>
-            <td>@component.id</td>
-            <td>@component.position</td>
-            <td>@component.label</td>
-            <td>@component.identifier</td>
-            <td>@TagDecorator.decorate(component.identifier, component.value.getOrElse("Unspecified"))</td>
-            <td>@component.key</td>
-          </tr>
-        }
-      </tbody>
-    </table>
-  </section>
+    </tbody>
+  </table>
   } else {
-    <section class="sectional">
-      <h3>None Available</h3>
-    </section>
+  <div class="row">
+    <div class="span12">
+      None Available
+    </div>
+  </div>
   }
 </div>
 <!-- End Hardware Details -->

--- a/test/resources/lshw-intel.xml
+++ b/test/resources/lshw-intel.xml
@@ -8,7 +8,6 @@
  <product>X8DTN (1234567890)</product>
  <vendor>Supermicro</vendor>
  <version>1234567890</version>
- <serial>1234567890</serial>
  <width units="bits">64</width>
  <configuration>
   <setting id="boot" value="normal" />

--- a/test/util/parsers/LshwParserSpec.scala
+++ b/test/util/parsers/LshwParserSpec.scala
@@ -50,6 +50,7 @@ class LshwParserSpec extends mutable.Specification {
 
           rep.base.product mustEqual "PowerEdge C6105 (N/A)"
           rep.base.vendor mustEqual "Winbond Electronics"
+          rep.base.serial mustEqual "FZ1NXQ1"
         }
       } // with a 10-gig card
       
@@ -94,6 +95,7 @@ class LshwParserSpec extends mutable.Specification {
           rep.has10GbNic must beFalse
           rep.macAddresses must have length 2
           rep.macAddresses must beNonEmptyStringSeq
+
         }
       } // basic
 
@@ -293,6 +295,7 @@ class LshwParserSpec extends mutable.Specification {
 
           rep.base.product mustEqual "PowerEdge C6105 (N/A)"
           rep.base.vendor mustEqual "Dell Inc."
+
         }
       }
     }


### PR DESCRIPTION
Adding intake and display of serial number from lshw (used at box). I cherry-picked an earlier PR. There are some GUI element changes on hardware details pages. Mostly cosmetic, I like what we have but this is fine too.

@Primer42 @jmackey @byxorna @defect 