### PR TITLE
Get rid of Threadlocal user option

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -23,7 +23,6 @@ object Application extends SecureWebController {
   )
 
   def login = Action { implicit req =>
-    setUser(None)
     req.queryString.get("location") match {
       case None =>
         Ok(html.login(loginForm))
@@ -33,7 +32,6 @@ object Application extends SecureWebController {
   }
 
   def authenticate = Action { implicit req =>
-    setUser(None)
     loginForm.bindFromRequest.fold(
       formWithErrors => {
         val tmp: Map[String,String] = formWithErrors.data - "password"
@@ -52,7 +50,6 @@ object Application extends SecureWebController {
   }
 
   def logout = SecureAction { implicit req =>
-    setUser(None)
     Redirect(routes.Application.login).withNewSession.flashing(
       "success" -> "You have been logged out"
     )

--- a/app/controllers/Security.scala
+++ b/app/controllers/Security.scala
@@ -79,10 +79,6 @@ trait SecureController extends Controller {
   def onUnauthorized: Action[AnyContent]
 
   def getUser(request: RequestHeader): User
-  def setUser(user: Option[User]): Option[User] = {
-    AppConfig.setUser(user)
-    user
-  }
 
   def Authenticated(action: Option[User] => Action[AnyContent])(implicit spec: SecuritySpecification) =
     SecureController.Authenticated(authenticate, onUnauthorized, authorize)(action)
@@ -116,14 +112,14 @@ trait SecureWebController extends SecureController {
   override def authenticate(request: RequestHeader) = User.fromMap(request.session.data) match {
     case Some(user) => user.isAuthenticated match {
       case true =>
-        setUser(Some(user))
+        Some(user)
       case false =>
         logger.debug("SecureWebController.authenticate: user found, not authenticated")
-        setUser(None)
+        None
     }
     case None =>
       logger.debug("SecureWebController.authenticate: user not found, session data not found")
-      setUser(None)
+      None
   }
 }
 
@@ -140,21 +136,21 @@ trait SecureApiController extends SecureController {
     request.headers.get(HeaderNames.AUTHORIZATION) match {
       case None =>
         logger.debug("Got API request with no auth header")
-        setUser(None)
+        None
       case Some(header) =>
         try {
           parseAuthHeader(header) match {
             case None =>
               logger.debug("Failed to authenticate request")
-              setUser(None)
+              None
             case Some(u) =>
               logger.debug("Logged in user %s".format(u.username))
-              setUser(Some(u))
+              Some(u)
           }
         } catch {
           case e: Throwable =>
             logger.warn("Caught exception authenticating user: " + e.getMessage)
-            setUser(None)
+            None
         }
     }
   }

--- a/app/controllers/actions/SecureAction.scala
+++ b/app/controllers/actions/SecureAction.scala
@@ -71,7 +71,6 @@ abstract class SecureAction(
   def execute(rd: RequestDataHolder): Result
 
   def executeAsync(rd: RequestDataHolder): Future[Result] = Future{
-    AppConfig.setUser(userOption)
     execute(rd)
   }
 

--- a/app/util/Tattler.scala
+++ b/app/util/Tattler.scala
@@ -7,7 +7,7 @@ import models.logs._
 trait TattlerHelper {
   val pString: Option[String] = None
   def message(user: Option[User], msg: String) = {
-    val username = user.filter(!_.isEmpty).orElse(AppConfig.getUser()).map(_.username)
+    val username = user.map(_.username)
       .orElse(pString).orElse(Some("Unknown")).get
     "User %s: %s".format(username, msg)
   }

--- a/app/util/config/AppConfig.scala
+++ b/app/util/config/AppConfig.scala
@@ -5,10 +5,7 @@ import models.{Asset, User}
 import play.api.{Logger, Mode, Play}
 
 object AppConfig {
-  var globalConfig: Option[PlayConfiguration] = None
-  private val UserSession = new ThreadLocal[Option[User]] {
-    override def initialValue(): Option[User] = None
-  }
+  var globalConfig: Option[PlayConfiguration] = None 
 
   // Ignore asset for dangerous commands
   def ignoredAssets = Feature.ignoreDangerousCommands.map(_.toUpperCase)
@@ -22,11 +19,6 @@ object AppConfig {
       app.mode
     }.getOrElse(Mode.Dev)
   }
-
-  def setUser(user: Option[User]) = UserSession.set(user)
-  def getUser(): Option[User] = UserSession.get()
-  def removeUser() = UserSession.remove()
-
 }
 
 trait AppConfig {

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ resolvers += "Twitter Repository" at "http://maven.twttr.com/"
 
 resolvers += "Sonatype-public" at "http://oss.sonatype.org/content/groups/public"
 
+resolvers += "Restlet repository" at "http://maven.restlet.org"
+
 parallelExecution in Test := false
 
 Keys.fork in Test := true


### PR DESCRIPTION
Summary:
Threadlocals are a poor mans globals and make just about as much sense
in a event based systems where thread can be put to use in different
context. The lack of calls to removeUser and the majority of uses
being `setUser(None)` is a good indication this isn't a good choice

@byxorna @nsauro @Primer42 