### PR TITLE
Update the package script for new solr version

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -31,7 +31,7 @@ rm -rf collins
 for dir in collins collins/lib collins/scripts $CONF_DIR; do
   mkdir $dir
 done
-for dir in $CONF_DIR/solr/conf $CONF_DIR/solr/data; do
+for dir in $CONF_DIR/solr/cores $CONF_DIR/solr/data; do
   mkdir -p $dir
 done
 
@@ -54,6 +54,6 @@ done
 cp ../conf/production_starter.conf $CONF_DIR/production.conf
 
 cp ../conf/solr/solr.xml $CONF_DIR/solr/
-cp -R ../conf/solr/conf/* $CONF_DIR/solr/conf/
+cp -R ../conf/solr/cores/* $CONF_DIR/solr/cores/
 cp -R ../conf/evolutions/* $CONF_DIR/evolutions/
 zip -r collins.zip collins


### PR DESCRIPTION
Summary:
The new solr version uses a cores folder structure and not
just a root conf directory.

Tested docker build works correctly. Updated package.

Fix for [issue](https://github.com/tumblr/collins/issues/304) reported by Keith

@yafsn @byxorna @Primer42 @defect @defect 