### PR TITLE
Fix the error message displayed when login fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ conf/solr/cores/collins/data
 .DS_Store
 Gemfile.lock
 
+.cache-main
+.cache-tests
+
 .idea
 .idea_modules
 *.iml

--- a/app/collins/util/security/LdapAuthenticationProvider.scala
+++ b/app/collins/util/security/LdapAuthenticationProvider.scala
@@ -133,12 +133,12 @@ class LdapAuthenticationProvider extends AuthenticationProvider {
           logger.info("Succesfully authenticated %s".format(username))
           Some(user)
         } { t =>
-          logger.warn("Failed to get groups for user %s".format(username))
+          logger.warn("Failed to get groups for user %s".format(username), t)
           None
         })
       })
     } { t =>
-      logger.error("Failed to bind to ldap server, please verify ldap configuration")
+      logger.error("Failed to bind to ldap server, please verify ldap configuration", t)
       None
     })
   }


### PR DESCRIPTION
Summary:
Exception handling to better report a login failure and not display
an exception code.

@Primer42 @byxorna @defect 