### PR TITLE
Remove use of async result during asset cancel request

### DIFF
--- a/app/collins/controllers/actions/asset/ProvisionAction.scala
+++ b/app/collins/controllers/actions/asset/ProvisionAction.scala
@@ -3,7 +3,6 @@ package collins.controllers.actions.asset
 import scala.concurrent.Future
 
 import play.api.mvc.SimpleResult
-import play.api.mvc.AsyncResult
 
 import collins.controllers.Permissions
 import collins.controllers.SecureController


### PR DESCRIPTION
Summary:
Remove deprecated API AsyncResult and replace with
Action. async when canceling an asset.

I tested intake and provisioning, however cancel itself requires softlayer and the particular change has not been tested. Given the change, I'm confident it is ok.

@byxorna @Primer42 @defect @roymarantz 