### PR TITLE
LSHW on KVM doesn't match 'bank'

### DIFF
--- a/app/collins/util/parsers/LshwParser.scala
+++ b/app/collins/util/parsers/LshwParser.scala
@@ -83,7 +83,7 @@ class LshwParser(txt: String) extends CommonParser[LshwRepresentation](txt) {
   }
 
   val memMatcher: PartialFunction[NodeSeq,Memory] = {
-    case n if (n \ "@class" text) == "memory" && (n \ "@id" text).contains("bank:") =>
+    case n if (n \ "@class" text) == "memory" && (n \ "@id" text).contains("bank") =>
       val asset = getAsset(n)
       val size = (n \ "size" text) match {
         case n if n.isEmpty => ByteStorageUnit(0)


### PR DESCRIPTION
Lshw within a KVM vm is reporting the node id for memory as 'bank' instead of 'bank:X'.  This change simply matches on 'bank' instead of 'bank:'.

ref: [bug-323](https://github.com/tumblr/collins/issues/323)