### PR TITLE
Make authentication logging less verbose

### DIFF
--- a/app/collins/util/security/AuthenticationProvider.scala
+++ b/app/collins/util/security/AuthenticationProvider.scala
@@ -21,7 +21,7 @@ trait AuthenticationProvider {
                                 .build(
                                   new CacheLoader[Credentials, Option[User]] {
                                     override def load(creds: Credentials): Option[User] = {
-                                      logger.info("Loading user %s from backend".format(creds._1))
+                                      logger.debug("Loading user %s from backend".format(creds._1))
                                       authenticate(creds._1, creds._2)
                                     }
                                   }
@@ -48,7 +48,7 @@ trait AuthenticationProvider {
 object AuthenticationProvider {
   val Default = new MockAuthenticationProvider
   val Types = Set("ldap", "file", "default")
-  def filename = AuthenticationProviderConfig.permissionsFile 
+  def filename = AuthenticationProviderConfig.permissionsFile
 
   private val logger = Logger("util.security.AuthenticationProvider")
 


### PR DESCRIPTION
Once collins is used as a certain rate, this is all that appears
in the logs, and it makes them essentially useless.

@maddalab @byxorna @defect @roymarantz 