### PR TITLE
Use the tryAuthCache method to avoid making auth queries continously.

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -111,6 +111,7 @@ object Global extends GlobalSettings with AuthenticationAccessor with CryptoAcce
       case false => authentication = Some(auth)
     }
   }
+
   def getAuthentication() = {
     val authen = authentication.getOrElse(throw new IllegalStateException("Authentication Provider not defined"))
     if (AuthenticationProviderConfig.authType != authen.authType) {
@@ -124,5 +125,4 @@ object Global extends GlobalSettings with AuthenticationAccessor with CryptoAcce
     }
     authen
   }
-
 }

--- a/app/collins/models/User.scala
+++ b/app/collins/models/User.scala
@@ -50,7 +50,7 @@ object User {
       case None => getProviderFromFramework()
       case Some(p) => p
     }
-    p.tryAuthCache(username, password) match {
+    p.authenticate(username, password) match {
       case None =>
         Stats.count("Authentication","Failure")
         None

--- a/app/collins/util/security/FileAuthenticationProvider.scala
+++ b/app/collins/util/security/FileAuthenticationProvider.scala
@@ -13,7 +13,7 @@ class FileAuthenticationProvider() extends AuthenticationProvider {
   def userfile = FileAuthenticationProviderConfig.userfile
   override val authType = Array("file")
 
-  lazy private val userCache = ConfigCache.create(10000L, FileUserLoader())
+  private val userCache = ConfigCache.create(10000L, FileUserLoader())
 
   override def authenticate(username: String, password: String): Option[User] = {
     user(username) match {

--- a/app/collins/util/security/MixedAuthenticationProvider.scala
+++ b/app/collins/util/security/MixedAuthenticationProvider.scala
@@ -1,6 +1,12 @@
 package collins.util.security
 
+import java.util.concurrent.TimeUnit
+
 import collins.models.User
+
+import com.google.common.cache.CacheBuilder
+import com.google.common.cache.CacheLoader
+import com.google.common.cache.LoadingCache
 
 /**
  * Exception encountered during authentication phase
@@ -8,14 +14,57 @@ import collins.models.User
 class AuthenticationException(msg: String) extends Exception(msg)
 
 /**
- * Provides authentication by a variety of methods
+ * Provides authentication by a variety of methods and caching logic (implements decorator pattern)
  */
 class MixedAuthenticationProvider(types: Array[String]) extends AuthenticationProvider {
-
-  /**
-   * @return The authorization type provided by this class
-   */
+  
+  private val providers = types.map({
+     case "default" => {
+       logger.trace("mock authentication type")
+       new MockAuthenticationProvider
+     }
+     case "file" => {
+       logger.trace("file authentication type")
+       new FileAuthenticationProvider()
+     }
+     case "ldap" => {
+       logger.trace("ldap authentication type")
+       new LdapAuthenticationProvider()
+     }
+     case t => {
+       throw new AuthenticationException("Invalid authentication type provided: " + t)
+     }
+  })
+  
   def authType = types
+  
+  /* Implement caching semantics for authentication */
+  type Credentials = Tuple2[String,String]
+  val cache: LoadingCache[Credentials, Option[User]] = CacheBuilder.newBuilder()
+                                .maximumSize(100)
+                                .expireAfterWrite(cacheTimeout, TimeUnit.MILLISECONDS)
+                                .build(
+                                  new CacheLoader[Credentials, Option[User]] {
+                                    override def load(creds: Credentials): Option[User] = {
+                                      logger.info("Loading user %s from backend".format(creds._1))
+                                      authenticate(creds._1, creds._2)
+                                    }
+                                  }
+                                )
+
+  def tryAuthCache(provider: AuthenticationProvider, username: String, password: String): Option[User] = {
+    if (!useCachedCredentials) {
+      provider.authenticate(username, password)
+    } else {
+      cache.get((username, password)) match {
+        case None =>
+          cache.invalidate((username, password))
+          None
+        case Some(u) =>
+          Some(u)
+      }
+    }
+  }
 
   /**
    * Attempt to authenticate user by each method specified in :types
@@ -24,31 +73,6 @@ class MixedAuthenticationProvider(types: Array[String]) extends AuthenticationPr
   def authenticate(username: String, password: String): Option[User] = {
     logger.debug("Beginning to try authentication types")
 
-    // Iterate over the types lazily, such that if one method passes, iteration stops
-    authType.flatMap({
-      case "default" => {
-        logger.trace("mock authentication type")
-        val defaultProvider = AuthenticationProvider.Default
-        val user = defaultProvider.tryAuthCache(username, password)
-        logger.debug("Tried mock authentication for %s, got back %s".format(username, user))
-        user
-      }
-      case "file" => {
-        logger.trace("file authentication type")
-        val fileProvider = new FileAuthenticationProvider()
-        val user = fileProvider.tryAuthCache(username, password)
-        logger.debug("Tried file authentication for %s, got back %s".format(username, user))
-        user
-      }
-      case "ldap" => {
-        val ldapProvider = new LdapAuthenticationProvider()
-        val user = ldapProvider.tryAuthCache(username, password)
-        logger.debug("Tried ldap authentication for %s, got back %s".format(username, user))
-        user
-      }
-      case t => {
-        throw new AuthenticationException("Invalid authentication type provided: " + t)
-      }
-    }).headOption
+    providers.flatMap { p => tryAuthCache(p, username, password) }.headOption
   }
 }

--- a/app/collins/util/security/MixedAuthenticationProvider.scala
+++ b/app/collins/util/security/MixedAuthenticationProvider.scala
@@ -29,20 +29,20 @@ class MixedAuthenticationProvider(types: Array[String]) extends AuthenticationPr
       case "default" => {
         logger.trace("mock authentication type")
         val defaultProvider = AuthenticationProvider.Default
-        val user = defaultProvider.authenticate(username, password)
+        val user = defaultProvider.tryAuthCache(username, password)
         logger.debug("Tried mock authentication for %s, got back %s".format(username, user))
         user
       }
       case "file" => {
         logger.trace("file authentication type")
         val fileProvider = new FileAuthenticationProvider()
-        val user = fileProvider.authenticate(username, password)
+        val user = fileProvider.tryAuthCache(username, password)
         logger.debug("Tried file authentication for %s, got back %s".format(username, user))
         user
       }
       case "ldap" => {
         val ldapProvider = new LdapAuthenticationProvider()
-        val user = ldapProvider.authenticate(username, password)
+        val user = ldapProvider.tryAuthCache(username, password)
         logger.debug("Tried ldap authentication for %s, got back %s".format(username, user))
         user
       }

--- a/app/collins/util/security/MixedAuthenticationProvider.scala
+++ b/app/collins/util/security/MixedAuthenticationProvider.scala
@@ -73,6 +73,6 @@ class MixedAuthenticationProvider(types: Array[String]) extends AuthenticationPr
   def authenticate(username: String, password: String): Option[User] = {
     logger.debug("Beginning to try authentication types")
 
-    providers.flatMap { p => tryAuthCache(p, username, password) }.headOption
+    providers.toStream.flatMap { p => tryAuthCache(p, username, password) }.headOption
   }
 }

--- a/test/collins/models/UserSpec.scala
+++ b/test/collins/models/UserSpec.scala
@@ -1,15 +1,15 @@
 package collins.models
 
-import collins.util.security.AuthenticationProvider
 import org.specs2.mutable._
 import java.io.File
+import collins.util.security.MockAuthenticationProvider
 
 object UserSpec extends Specification {
 
   "The User Model" should {
     "handle authentication" in {
       "with default authentication" in {
-        val provider = AuthenticationProvider.Default
+        val provider = new MockAuthenticationProvider
         User.authenticate("blake", "admin:first", Some(provider)) must beSome[User]
         User.authenticate("no", "suchuser", Some(provider)) must beNone
       }

--- a/test/collins/util/security/AuthenticationProviderSpec.scala
+++ b/test/collins/util/security/AuthenticationProviderSpec.scala
@@ -11,7 +11,7 @@ object AuthenticationProviderSpec extends Specification with collins.ResourceFin
 
   "Authentication Providers" should {
     "work with default authentication" >> {
-      val provider = AuthenticationProvider.Default
+      val provider = new MockAuthenticationProvider
       provider.authenticate("blake", "admin:first") must beSome[User]
       provider.authenticate("no", "suchuser") must beNone
     }


### PR DESCRIPTION
See #331 

Why would logging of backend auth become verbose for no apparent reason? Probably because we are instantiating a [new] (https://github.com/tumblr/collins/blob/master/app/collins/util/security/MixedAuthenticationProvider.scala#L44) provider for ever login request which is effectively busting the cache.

This attempts to address that along with addressing some software design issues. 

@Primer42 @defect @byxorna @roymarantz 