### PR TITLE
Fix an issue where tattler was not reporting the correct user for changes

### DIFF
--- a/app/collins/controllers/AssetWebApi.scala
+++ b/app/collins/controllers/AssetWebApi.scala
@@ -8,7 +8,6 @@ import play.api.mvc.Results
 import collins.controllers.actions.asset.DeleteAction
 import collins.controllers.actors.AssetCancelProcessor
 import collins.models.Asset
-import collins.util.UserTattler
 import collins.util.concurrent.BackgroundProcessor
 import collins.util.concurrent.BackgroundProcessor.SendType
 import collins.util.config.AppConfig
@@ -32,7 +31,8 @@ trait AssetWebApi {
             case Right(res) => res match {
               case Left(err) => err.asResult
               case Right(success) =>
-                UserTattler.notice(asset.get, user, "Server cancelled")
+                // TODO: fix asset.get
+                tattler(user).notice("Server cancelled", asset.get)
                 ResponseData(Results.Ok, JsObject(Seq("SUCCESS" -> JsNumber(success)))).asResult
             }
         }

--- a/app/collins/controllers/Security.scala
+++ b/app/collins/controllers/Security.scala
@@ -14,6 +14,10 @@ import play.api.mvc.Results
 import play.twirl.api.Txt
 
 import collins.models.User
+import collins.models.logs.LogSource
+import collins.util.Tattler
+import collins.util.ApplicationTattler
+import collins.util.InternalTattler
 import collins.util.security.AuthenticationProvider
 import collins.util.security.SecuritySpecification
 
@@ -71,6 +75,14 @@ object SecureController {
 trait SecureController extends Controller {
   protected val logger = Logger.logger
 
+  /** Obtains a tattler for this controller */
+  def tattler(user: Option[User]): Tattler = {
+    user.filter { _.isAuthenticated() }.map { new ApplicationTattler(_, logSource) }.getOrElse(InternalTattler)
+  }
+
+  /** Log source identifier to use */
+  def logSource : LogSource.LogSource
+  
   /** Controllers that extend this trait can override the default authorize behavior */
   def authorize(user: User, spec: SecuritySpecification): Boolean = {
     AuthenticationProvider.userIsAuthorized(user, spec)
@@ -92,6 +104,8 @@ trait SecureWebController extends SecureController {
   val unauthorizedRoute = routes.Application.login.url
   def securityMessage(req: RequestHeader) = ("security" -> "The specified resource requires additional authorization")
 
+  def logSource = LogSource.User
+  
   override def onUnauthorized = Action { implicit request =>
     // If user is not logged in and accesses a page, store the location so they can be redirected
     // after authentication
@@ -123,6 +137,9 @@ trait SecureWebController extends SecureController {
 
 /** Used for API access, authenticates based on basic auth */
 trait SecureApiController extends SecureController {
+  
+  def logSource = LogSource.Api
+  
   override def onUnauthorized = Action { implicit request =>
     Results.Unauthorized(Txt("Invalid Username/Password specified"))
   }

--- a/app/collins/controllers/actions/SecureAction.scala
+++ b/app/collins/controllers/actions/SecureAction.scala
@@ -159,6 +159,7 @@ abstract class SecureAction(
         None
     validationResults.getOrElse(validate())
   }
+  
   private def handleExecution(rd: RequestDataHolder): Future[Result] = {
     val executionResults =
       if (isReadRequest)
@@ -173,6 +174,7 @@ abstract class SecureAction(
         None
     executionResults.getOrElse(execute(rd))
   }
+  
   private def run(): Future[Result] = handleValidation() match {
     case Left(rd) => Promise.successful(handleError(rd)).future
     case Right(rd) => handleExecution(rd) map {
@@ -181,4 +183,5 @@ abstract class SecureAction(
     }
   }
 
+  def tattler = securityHandler.tattler(userOption())
 }

--- a/app/collins/controllers/actions/asset/CreateAction.scala
+++ b/app/collins/controllers/actions/asset/CreateAction.scala
@@ -83,7 +83,8 @@ case class CreateAction(
 
   override def execute(rd: RequestDataHolder) = Future { rd match {
     case ActionDataHolder(assetTag, genIpmi, assetType, assetStatus) =>
-      AssetLifecycle.createAsset(assetTag, assetType, genIpmi, assetStatus) match {
+      val lifeCycle = new AssetLifecycle(userOption(), tattler)
+      lifeCycle.createAsset(assetTag, assetType, genIpmi, assetStatus) match {
         case Left(throwable) =>
           handleError(
             RequestDataHolder.error500("Could not create asset: %s".format(throwable.getMessage))

--- a/app/collins/controllers/actions/asset/DeleteAction.scala
+++ b/app/collins/controllers/actions/asset/DeleteAction.scala
@@ -14,7 +14,6 @@ import collins.controllers.actions.RequestDataHolder
 import collins.controllers.actions.SecureAction
 import collins.models.AssetLifecycle
 import collins.models.asset.AssetDeleter
-import collins.util.SystemTattler
 import collins.util.security.SecuritySpecification
 import collins.validation.StringUtil
 
@@ -57,7 +56,7 @@ case class DeleteAction(
             val errMsg = "User deleted asset %s. Reason: %s".format(
               definedAsset.tag, options.get("reason").getOrElse("Unspecified")
             )
-            SystemTattler.safeError(errMsg)
+            tattler.error(errMsg, definedAsset)
             Api.statusResponse(AssetDeleter.purge(definedAsset))
           } else {
             Api.statusResponse(status)

--- a/app/collins/controllers/actions/asset/DeleteAction.scala
+++ b/app/collins/controllers/actions/asset/DeleteAction.scala
@@ -46,7 +46,8 @@ case class DeleteAction(
 
   override def execute(rd: RequestDataHolder) = Future { rd match {
     case ActionDataHolder(options) =>
-      AssetLifecycle.decommissionAsset(definedAsset, options) match {
+      val lifeCycle = new AssetLifecycle(userOption(), tattler)
+      lifeCycle.decommissionAsset(definedAsset, options) match {
         case Left(throwable) =>
           handleError(
             RequestDataHolder.error409("Illegal state transition: %s".format(throwable.getMessage))

--- a/app/collins/controllers/actions/asset/DeleteAttributeAction.scala
+++ b/app/collins/controllers/actions/asset/DeleteAttributeAction.scala
@@ -46,7 +46,7 @@ case class DeleteAttributeAction(
 
   override def execute(rd: RequestDataHolder) = Future { rd match {
     case adh@ActionDataHolder(attribute, gid) =>
-      AssetLifecycle.updateAssetAttributes(definedAsset, mapForUpdates(adh)) match {
+      AssetLifecycle.updateAssetAttributes(definedAsset, mapForUpdates(adh), userOption) match {
         case Left(throwable) =>
           handleError(RequestDataHolder.error500("Error deleting asset attributes"))
         case Right(status) =>

--- a/app/collins/controllers/actions/asset/DeleteAttributeAction.scala
+++ b/app/collins/controllers/actions/asset/DeleteAttributeAction.scala
@@ -46,7 +46,8 @@ case class DeleteAttributeAction(
 
   override def execute(rd: RequestDataHolder) = Future { rd match {
     case adh@ActionDataHolder(attribute, gid) =>
-      AssetLifecycle.updateAssetAttributes(definedAsset, mapForUpdates(adh), userOption) match {
+      val lifeCycle = new AssetLifecycle(userOption(), tattler)
+      lifeCycle.updateAssetAttributes(definedAsset, mapForUpdates(adh)) match {
         case Left(throwable) =>
           handleError(RequestDataHolder.error500("Error deleting asset attributes"))
         case Right(status) =>

--- a/app/collins/controllers/actions/asset/PowerManagementActionHelper.scala
+++ b/app/collins/controllers/actions/asset/PowerManagementActionHelper.scala
@@ -19,7 +19,6 @@ import collins.power.Verify
 import collins.power.management.PowerManagementConfig
 import collins.shell.CommandResult
 import collins.util.IpmiCommand
-import collins.util.UserTattler
 import collins.util.concurrent.BackgroundProcessor
 import collins.util.config.AppConfig
 import collins.util.plugins.IpmiPowerCommand
@@ -145,7 +144,7 @@ abstract class PowerManagementActionHelper(
       case Verify | PowerState | Identify =>
         // don't log verify, state, identify (normal lifecycle)
       case o =>
-        UserTattler.warning(definedAsset, userOption, msg)
+        tattler.warning(msg, definedAsset)
     }
   }
 

--- a/app/collins/controllers/actions/asset/ProvisionUtil.scala
+++ b/app/collins/controllers/actions/asset/ProvisionUtil.scala
@@ -228,10 +228,11 @@ trait Provisions extends ProvisionUtil with AssetAction { self: SecureAction =>
     val ActionDataHolder(asset, pRequest, _, attribs) = adh
     val plugin = SoftLayer.plugin.get
     val slId = plugin.softLayerId(asset).get
-    if (attribs.nonEmpty)
-      AssetLifecycle.updateAssetAttributes(
-        Asset.findById(asset.getId).get, attribs, userOption
-      )
+    if (attribs.nonEmpty) {
+      val lifeCycle = new AssetLifecycle(userOption(), tattler)
+      lifeCycle.updateAssetAttributes(Asset.findById(asset.getId).get, attribs)
+    }
+    
     BackgroundProcessor.send(ActivationProcessor(slId)(request)) { res =>
       processProvisionAction(res) {
         case true =>
@@ -265,8 +266,9 @@ trait Provisions extends ProvisionUtil with AssetAction { self: SecureAction =>
         Future(err)
       case None =>
         if (attribs.nonEmpty) {
-          AssetLifecycle.updateAssetAttributes(
-            Asset.findById(asset.getId).get, attribs, userOption
+          val lifeCycle = new AssetLifecycle(userOption(), tattler)
+          lifeCycle.updateAssetAttributes(
+            Asset.findById(asset.getId).get, attribs
           )
           setAsset(Asset.findById(asset.getId))
         }

--- a/app/collins/controllers/actions/asset/ProvisionUtil.scala
+++ b/app/collins/controllers/actions/asset/ProvisionUtil.scala
@@ -27,8 +27,6 @@ import collins.models.Truthy
 import collins.provisioning.ProvisionerPlugin
 import collins.provisioning.ProvisionerRequest
 import collins.provisioning.{ProvisionerRoleData => ProvisionerRole}
-import collins.util.ApiTattler
-import collins.util.UserTattler
 import collins.util.concurrent.BackgroundProcessor
 import collins.util.concurrent.BackgroundProcessor.SendType
 import collins.util.config.Feature
@@ -220,14 +218,10 @@ trait Provisions extends ProvisionUtil with AssetAction { self: SecureAction =>
   }
 
   protected def tattle(message: String, error: Boolean) {
-    val tattler = isHtml match {
-      case true => UserTattler
-      case false => ApiTattler
-    }
     if (error)
-      tattler.critical(definedAsset, userOption, message)
+      tattler.critical(message, definedAsset)
     else
-      tattler.note(definedAsset, userOption, message)
+      tattler.note(message, definedAsset)
   }
 
   protected def activateAsset(adh: ActionDataHolder): Future[Result] = {
@@ -236,7 +230,7 @@ trait Provisions extends ProvisionUtil with AssetAction { self: SecureAction =>
     val slId = plugin.softLayerId(asset).get
     if (attribs.nonEmpty)
       AssetLifecycle.updateAssetAttributes(
-        Asset.findById(asset.getId).get, attribs
+        Asset.findById(asset.getId).get, attribs, userOption
       )
     BackgroundProcessor.send(ActivationProcessor(slId)(request)) { res =>
       processProvisionAction(res) {
@@ -272,7 +266,7 @@ trait Provisions extends ProvisionUtil with AssetAction { self: SecureAction =>
       case None =>
         if (attribs.nonEmpty) {
           AssetLifecycle.updateAssetAttributes(
-            Asset.findById(asset.getId).get, attribs
+            Asset.findById(asset.getId).get, attribs, userOption
           )
           setAsset(Asset.findById(asset.getId))
         }

--- a/app/collins/controllers/actions/asset/UpdateAction.scala
+++ b/app/collins/controllers/actions/asset/UpdateAction.scala
@@ -105,9 +105,9 @@ case class UpdateAction(
       case adh@ActionDataHolder(map) =>
         val results: collins.models.AssetLifecycle.Status[Boolean] =
           if (onlyAttributes)
-            AssetLifecycle.updateAssetAttributes(definedAsset, map)
+            AssetLifecycle.updateAssetAttributes(definedAsset, map, userOption)
           else
-            AssetLifecycle.updateAsset(definedAsset, map)
+            AssetLifecycle.updateAsset(definedAsset, map, userOption)
         results match {
           case Left(exception) =>
             handleError(

--- a/app/collins/controllers/actions/asset/UpdateAction.scala
+++ b/app/collins/controllers/actions/asset/UpdateAction.scala
@@ -103,11 +103,12 @@ case class UpdateAction(
   override def execute(rd: RequestDataHolder) = Future { 
     rd match {
       case adh@ActionDataHolder(map) =>
-        val results: collins.models.AssetLifecycle.Status[Boolean] =
+        val lifeCycle = new AssetLifecycle(userOption(), tattler)
+        val results: AssetLifecycle.Status[Boolean] =
           if (onlyAttributes)
-            AssetLifecycle.updateAssetAttributes(definedAsset, map, userOption)
+            lifeCycle.updateAssetAttributes(definedAsset, map)
           else
-            AssetLifecycle.updateAsset(definedAsset, map, userOption)
+            lifeCycle.updateAsset(definedAsset, map)
         results match {
           case Left(exception) =>
             handleError(

--- a/app/collins/controllers/actions/asset/UpdateForMaintenance.scala
+++ b/app/collins/controllers/actions/asset/UpdateForMaintenance.scala
@@ -86,9 +86,9 @@ case class UpdateForMaintenanceAction(
     rd match {
       case adh@ActionDataHolder(status, description, state) =>
         val success = if (status.id == AssetStatus.Maintenance.get.id) {
-          Maintenance.toMaintenance(definedAsset, description, state)
+          Maintenance.toMaintenance(definedAsset, description, state, userOption)
         } else {
-          Maintenance.fromMaintenance(definedAsset, description, status.name, state)
+          Maintenance.fromMaintenance(definedAsset, description, status.name, state, userOption)
         }
         success match {
           case true => Api.statusResponse(true)

--- a/app/collins/controllers/actions/asset/UpdateForMaintenance.scala
+++ b/app/collins/controllers/actions/asset/UpdateForMaintenance.scala
@@ -17,6 +17,7 @@ import collins.controllers.forms.stateFormat
 import collins.controllers.forms.statusFormat
 import collins.models.State
 import collins.models.{Status => AssetStatus}
+import collins.models.AssetLifecycle
 import collins.util.MessageHelper
 import collins.util.plugins.Maintenance
 import collins.util.security.SecuritySpecification
@@ -85,10 +86,11 @@ case class UpdateForMaintenanceAction(
   override def execute(rd: RequestDataHolder) = Future { 
     rd match {
       case adh@ActionDataHolder(status, description, state) =>
+        val lifeCycle = new AssetLifecycle(userOption, tattler)
         val success = if (status.id == AssetStatus.Maintenance.get.id) {
-          Maintenance.toMaintenance(definedAsset, description, state, userOption)
+          Maintenance.toMaintenance(definedAsset, description, state, lifeCycle)
         } else {
-          Maintenance.fromMaintenance(definedAsset, description, status.name, state, userOption)
+          Maintenance.fromMaintenance(definedAsset, description, status.name, state, lifeCycle)
         }
         success match {
           case true => Api.statusResponse(true)

--- a/app/collins/controllers/actions/asset/UpdateStatusAction.scala
+++ b/app/collins/controllers/actions/asset/UpdateStatusAction.scala
@@ -96,7 +96,8 @@ case class UpdateStatusAction(
   override def execute(rd: RequestDataHolder) = Future { 
     rd match {
       case ActionDataHolder(status, state, reason) =>
-        AssetLifecycle.updateAssetStatus(definedAsset, status, state, reason, userOption).fold(
+        val lifeCycle = new AssetLifecycle(userOption, tattler)
+        lifeCycle.updateAssetStatus(definedAsset, status, state, reason).fold(
           e => Api.errorResponse("Error updating status", Status.InternalServerError, Some(e)),
           b => Api.statusResponse(b)
         )

--- a/app/collins/controllers/actions/asset/UpdateStatusAction.scala
+++ b/app/collins/controllers/actions/asset/UpdateStatusAction.scala
@@ -96,7 +96,7 @@ case class UpdateStatusAction(
   override def execute(rd: RequestDataHolder) = Future { 
     rd match {
       case ActionDataHolder(status, state, reason) =>
-        AssetLifecycle.updateAssetStatus(definedAsset, status, state, reason).fold(
+        AssetLifecycle.updateAssetStatus(definedAsset, status, state, reason, userOption).fold(
           e => Api.errorResponse("Error updating status", Status.InternalServerError, Some(e)),
           b => Api.statusResponse(b)
         )

--- a/app/collins/controllers/actions/ipaddress/CreateAction.scala
+++ b/app/collins/controllers/actions/ipaddress/CreateAction.scala
@@ -19,7 +19,6 @@ import collins.controllers.actions.SecureAction
 import collins.models.Asset
 import collins.models.IpAddresses
 import collins.models.shared.IpAddressConfig
-import collins.util.ApiTattler
 import collins.util.security.SecuritySpecification
 
 // Allocate addresses for an asset
@@ -70,7 +69,7 @@ case class CreateAction(
           case false => pool
         }
         val created = IpAddresses.createForAsset(asset, count, Some(poolName))
-        ApiTattler.notice(asset, userOption, "Created %d IP addresses".format(created.size))
+        tattler.notice("Created %d IP addresses".format(created.size), asset)
         ResponseData(Status.Created, created.toJson)
       } catch {
         case e: SQLException =>

--- a/app/collins/controllers/actions/ipaddress/DeleteAction.scala
+++ b/app/collins/controllers/actions/ipaddress/DeleteAction.scala
@@ -15,7 +15,6 @@ import collins.controllers.actions.SecureAction
 import collins.controllers.validators.ParamValidation
 import collins.models.Asset
 import collins.models.IpAddresses
-import collins.util.ApiTattler
 import collins.util.security.SecuritySpecification
 
 // Delete addressed for an asset, optionally by pool
@@ -43,7 +42,7 @@ case class DeleteAction(
     rd match {
       case ActionDataHolder(asset, pool) =>
         val deleted = IpAddresses.deleteByAssetAndPool(asset, pool)
-        ApiTattler.notice(asset, userOption, "Deleted %d IP addresses".format(deleted))
+        tattler.notice("Deleted %d IP addresses".format(deleted), asset)
         ResponseData(Status.Ok, JsObject(Seq("DELETED" -> JsNumber(deleted))))
     }
   }

--- a/app/collins/controllers/actions/ipaddress/UpdateAction.scala
+++ b/app/collins/controllers/actions/ipaddress/UpdateAction.scala
@@ -18,7 +18,6 @@ import collins.controllers.validators.ParamValidation
 import collins.models.Asset
 import collins.models.IpAddresses
 import collins.models.shared.IpAddressConfig
-import collins.util.ApiTattler
 import collins.util.IpAddress
 import collins.util.security.SecuritySpecification
 import collins.validation.StringUtil
@@ -100,12 +99,12 @@ case class UpdateAction(
   protected def handleUpdate(asset: Asset, address: IpAddresses) = {
     IpAddresses.update(address) match {
       case 1 =>
-        ApiTattler.notice(asset, userOption, "Updated IP address %s".format(address.dottedAddress))
+        tattler.notice("Updated IP address %s".format(address.dottedAddress), asset)
         (Status.Ok, true)
       case _ =>
-        ApiTattler.warning(asset, userOption, "Failed to update address %s".format(
+        tattler.warning("Failed to update address %s".format(
           address.dottedAddress
-        ))
+        ), asset)
         (Status.InternalServerError, false)
     }
   }
@@ -113,12 +112,12 @@ case class UpdateAction(
   protected def handleCreate(asset: Asset, address: IpAddresses) = {
     IpAddresses.create(address).id match {
       case fail if fail <= 0 =>
-        ApiTattler.warning(asset, userOption, "Failed to create address %s".format(
+        tattler.warning("Failed to create address %s".format(
           address.dottedAddress
-        ))
+        ), asset)
         (Status.InternalServerError, false)
       case success =>
-        ApiTattler.notice(asset, userOption, "Created IP address %s".format(address.dottedAddress))
+        tattler.notice("Created IP address %s".format(address.dottedAddress), asset)
         (Status.Created, true)
     }
   }

--- a/app/collins/controllers/actions/logs/CreateAction.scala
+++ b/app/collins/controllers/actions/logs/CreateAction.scala
@@ -25,7 +25,6 @@ import collins.models.logs.LogFormat
 import collins.models.logs.LogMessageType
 import collins.models.logs.LogSource
 import collins.util.MessageHelper
-import collins.util.TattlerHelper
 import collins.util.config.Feature
 import collins.util.security.SecuritySpecification
 
@@ -90,7 +89,7 @@ case class CreateAction(
       error => Left(RequestDataHolder.error400(MessageError)),
       success => logFromRequestData(success) { case(messageBody, messageSource, messageType) =>
         val msg = formatStringMessage(messageBody)
-        AssetLog(asset, msg, LogFormat.PlainText, messageSource, messageType)
+        AssetLog(asset, userOption().map { _.username }.getOrElse(""), msg, LogFormat.PlainText, messageSource, messageType)
       }
     )
   }
@@ -107,7 +106,7 @@ case class CreateAction(
       case None => Left(RequestDataHolder.error400(MessageError))
       case Some(message) =>
         logFromRequestData(message, osource, otype) { case(messageBody,messageSource,messageType) =>
-          AssetLog(asset, messageBody, LogFormat.Json, LogSource.Api, messageType)
+          AssetLog(asset, userOption().map { _.username }.getOrElse(""), messageBody, LogFormat.Json, messageSource, messageType)
         }
     }
   }
@@ -127,8 +126,7 @@ case class CreateAction(
 
   // Given a text message, strip out bad HTML and include the user in the text
   protected def formatStringMessage(txt: String): String = {
-    val escapedMessage = Jsoup.clean(txt, Whitelist.basic())
-    TattlerHelper.message(userOption, escapedMessage)
+      Jsoup.clean(txt, Whitelist.basic())
   }
 
   // Given some form data provide defaults and convert things to None when invalid

--- a/app/collins/controllers/actions/resources/IntakeStage3Action.scala
+++ b/app/collins/controllers/actions/resources/IntakeStage3Action.scala
@@ -93,7 +93,8 @@ case class IntakeStage3Action(
   
         val updateMap = basicMap ++ customFieldMap ++ powerMap
         // Asset Lifecycle business
-        AssetLifecycle.updateAsset(definedAsset, updateMap, userOption) match {
+        val lifeCycle = new AssetLifecycle(userOption, tattler)
+        lifeCycle.updateAsset(definedAsset, updateMap) match {
   
           case Left(error) =>
             handleError(RequestDataHolder.error400(error.getMessage))

--- a/app/collins/controllers/actions/resources/IntakeStage3Action.scala
+++ b/app/collins/controllers/actions/resources/IntakeStage3Action.scala
@@ -93,7 +93,7 @@ case class IntakeStage3Action(
   
         val updateMap = basicMap ++ customFieldMap ++ powerMap
         // Asset Lifecycle business
-        AssetLifecycle.updateAsset(definedAsset, updateMap) match {
+        AssetLifecycle.updateAsset(definedAsset, updateMap, userOption) match {
   
           case Left(error) =>
             handleError(RequestDataHolder.error400(error.getMessage))

--- a/app/collins/controllers/actors/AssetCancelProcessor.scala
+++ b/app/collins/controllers/actors/AssetCancelProcessor.scala
@@ -48,7 +48,7 @@ case class AssetCancelProcessor(tag: String, userTimeout: Option[FiniteDuration]
               case ticketId =>
                 Asset.inTransaction {
                   MetaWrapper.createMeta(asset, Map("CANCEL_TICKET" -> ticketId.toString))
-                  AssetLifecycle.updateAssetStatus(asset, AStatus.Cancelled, None, reason)
+                  AssetLifecycle.updateAssetStatus(asset, AStatus.Cancelled, None, reason, None)
                 }
                 Await.result(plugin.setNote(n, "Cancelled: %s".format(reason)), timeout)
                 Right(ticketId)

--- a/app/collins/controllers/actors/AssetCancelProcessor.scala
+++ b/app/collins/controllers/actors/AssetCancelProcessor.scala
@@ -16,6 +16,7 @@ import collins.models.AssetLifecycle
 import collins.models.MetaWrapper
 import collins.models.{Status => AStatus}
 import collins.softlayer.SoftLayerConfig
+import collins.util.InternalTattler
 import collins.util.concurrent.BackgroundProcess
 import collins.util.plugins.SoftLayer
 
@@ -48,7 +49,8 @@ case class AssetCancelProcessor(tag: String, userTimeout: Option[FiniteDuration]
               case ticketId =>
                 Asset.inTransaction {
                   MetaWrapper.createMeta(asset, Map("CANCEL_TICKET" -> ticketId.toString))
-                  AssetLifecycle.updateAssetStatus(asset, AStatus.Cancelled, None, reason, None)
+                  val lifeCycle = new AssetLifecycle(None, InternalTattler)
+                  lifeCycle.updateAssetStatus(asset, AStatus.Cancelled, None, reason)
                 }
                 Await.result(plugin.setNote(n, "Cancelled: %s".format(reason)), timeout)
                 Right(ticketId)

--- a/app/collins/models/AssetLog.scala
+++ b/app/collins/models/AssetLog.scala
@@ -40,6 +40,7 @@ import collins.models.shared.ValidatedEntity
 case class AssetLog(
   asset_id: Long,
   created: Timestamp,
+  created_by: String,
   format: LogFormat = LogFormat.PlainText,
   source: LogSource = LogSource.Internal,
   message_type: LogMessageType = LogMessageType.Emergency,
@@ -47,7 +48,7 @@ case class AssetLog(
   id: Long = 0) extends ValidatedEntity[Long]
 {
   def this() = // 0 arg constructor since we have enums
-    this(0,new Date().asTimestamp, LogFormat.PlainText, LogSource.Internal, LogMessageType.Emergency, "", 0)
+    this(0,new Date().asTimestamp, "", LogFormat.PlainText, LogSource.Internal, LogMessageType.Emergency, "", 0)
 
   override def validate() {
     require(message != null && message.length > 0)
@@ -85,6 +86,7 @@ case class AssetLog(
 
   def getId(): Long = id
   def getAssetId(): Long = asset_id
+  def getCreatedBy(): String = created_by
   def getAssetTag(): String = getAsset().tag
   def getAsset(): Asset = Asset.findById(getAssetId()).get
 
@@ -136,59 +138,59 @@ object AssetLog extends Schema with AnormAdapter[AssetLog] {
 
   override def delete(t: AssetLog): Int = 0
 
-  def apply(asset: Asset, message: String, format: LogFormat, source: LogSource, mt: LogMessageType) = {
-    new AssetLog(asset.getId, new Date().asTimestamp, format, source, mt, message)
+  def apply(asset: Asset, createdBy: String, message: String, format: LogFormat, source: LogSource, mt: LogMessageType) = {
+    new AssetLog(asset.getId, new Date().asTimestamp, createdBy, format, source, mt, message)
   }
 
   // A "panic" condition - notify all tech staff on call? (earthquake? tornado?) - affects multiple
   // apps/servers/sites...
-  def emergency(asset: Asset, message: String, format: LogFormat, source: LogSource) = {
-      apply(asset, message, format, source, LogMessageType.Emergency)
+  def emergency(asset: Asset, createdBy: String, message: String, format: LogFormat, source: LogSource) = {
+      apply(asset, createdBy, message, format, source, LogMessageType.Emergency)
   }
 
   // Should be corrected immediately, but indicates failure in a primary system - fix CRITICAL
   // problems before ALERT - example is loss of primary ISP connection
-  def critical(asset: Asset, message: String, format: LogFormat, source: LogSource) = {
-      apply(asset, message, format, source, LogMessageType.Critical)
+  def critical(asset: Asset, createdBy: String, message: String, format: LogFormat, source: LogSource) = {
+      apply(asset, createdBy, message, format, source, LogMessageType.Critical)
   }
 
   // Should be corrected immediately - notify staff who can fix the problem - example is loss of
   // backup ISP connection
-  def alert(asset: Asset, message: String, format: LogFormat, source: LogSource) = {
-      apply(asset, message, format, source, LogMessageType.Alert)
+  def alert(asset: Asset, createdBy: String, message: String, format: LogFormat, source: LogSource) = {
+      apply(asset, createdBy, message, format, source, LogMessageType.Alert)
   }
 
   // Non-urgent failures - these should be relayed to developers or admins; each item must be
   // resolved within a given time
-  def error(asset: Asset, message: String, format: LogFormat, source: LogSource) = {
-      apply(asset, message, format, source, LogMessageType.Error)
+  def error(asset: Asset, createdBy: String, message: String, format: LogFormat, source: LogSource) = {
+      apply(asset, createdBy, message, format, source, LogMessageType.Error)
   }
 
   // Warning messages - not an error, but indication that an error will occur if action is not
   // taken, e.g. file system 85% full - each item must be resolved within a given time
-  def warning(asset: Asset, message: String, format: LogFormat, source: LogSource) = {
-      apply(asset, message, format, source, LogMessageType.Warning)
+  def warning(asset: Asset, createdBy: String, message: String, format: LogFormat, source: LogSource) = {
+      apply(asset, createdBy, message, format, source, LogMessageType.Warning)
   }
 
   // Events that are unusual but not error conditions - might be summarized in an email to
   // developers or admins to spot potential problems - no immediate action required
-  def notice(asset: Asset, message: String, format: LogFormat, source: LogSource) = {
-      apply(asset, message, format, source, LogMessageType.Notice)
+  def notice(asset: Asset, createdBy: String, message: String, format: LogFormat, source: LogSource) = {
+      apply(asset, createdBy, message, format, source, LogMessageType.Notice)
   }
 
-  def note(asset: Asset, message: String, format: LogFormat, source: LogSource) = {
-      apply(asset, message, format, source, LogMessageType.Note)
+  def note(asset: Asset, createdBy: String, message: String, format: LogFormat, source: LogSource) = {
+      apply(asset, createdBy, message, format, source, LogMessageType.Note)
   }
 
   // Normal operational messages - may be harvested for reporting, measuring throughput, etc - no
   // action required
-  def informational(asset: Asset, message: String, format: LogFormat, source: LogSource) = {
-      apply(asset, message, format, source, LogMessageType.Informational)
+  def informational(asset: Asset, createdBy: String, message: String, format: LogFormat, source: LogSource) = {
+      apply(asset, createdBy, message, format, source, LogMessageType.Informational)
   }
 
   //Info useful to developers for debugging the application, not useful during operations
-  def debug(asset: Asset, message: String, format: LogFormat, source: LogSource) = {
-      apply(asset, message, format, source, LogMessageType.Debug)
+  def debug(asset: Asset, createdBy: String, message: String, format: LogFormat, source: LogSource) = {
+      apply(asset, createdBy, message, format, source, LogMessageType.Debug)
   }
 
   override def get(log: AssetLog) = inTransaction {

--- a/app/collins/models/AssetMetaValue.scala
+++ b/app/collins/models/AssetMetaValue.scala
@@ -237,12 +237,12 @@ object AssetMetaValue extends Schema with BasicModel[AssetMetaValue] {
         val metaName = newValue.getMeta().name
         val newValueS = if (Feature.encryptedTags.map(_.name).contains(metaName)) {
           val msg = "Value of '%s' was changed".format(metaName)
-          InternalTattler.notice(newValue.getAsset, None, msg)
+          InternalTattler.notice(msg, newValue.getAsset)
         } else {
           val msg = "Deleting old %s value '%s', setting to '%s'".format(
                     AssetMeta.findById(newValue.asset_meta_id).map(_.name).getOrElse("Unknown"),
                     oValue.value, newValue.value)
-          InternalTattler.notice(newValue.getAsset, None, msg)
+          InternalTattler.notice(msg, newValue.getAsset)
         }
     }
   }

--- a/app/collins/models/conversions.scala
+++ b/app/collins/models/conversions.scala
@@ -86,6 +86,7 @@ object conversions {
     override def reads(json: JsValue) = JsSuccess(AssetLog(
       (json \ "ASSET_ID").as[Long],
       (json \ "CREATED").as[Timestamp],
+      (json \ "CREATED_BY").as[String],
       logs.LogFormat.withName((json \ "FORMAT").as[String]),
       logs.LogSource.withName((json \ "SOURCE").as[String]),
       logs.LogMessageType.withName((json \ "TYPE").as[String]),
@@ -96,6 +97,7 @@ object conversions {
       "ID" -> Json.toJson(log.id),
       "ASSET_TAG" -> Json.toJson(Asset.findById(log.asset_id).map(_.tag).getOrElse("Unknown")),
       "CREATED" -> Json.toJson(log.created),
+      "CREATED_BY" -> Json.toJson(log.created_by),
       "FORMAT" -> Json.toJson(log.format.toString),
       "SOURCE" -> Json.toJson(log.source.toString),
       "TYPE" -> Json.toJson(log.message_type.toString),

--- a/app/collins/models/conversions.scala
+++ b/app/collins/models/conversions.scala
@@ -83,6 +83,7 @@ object conversions {
     ))
   }
   implicit object AssetLogFormat extends Format[AssetLog] {
+    val df = new SimpleDateFormat("d/M/yy HH:mm:ss")
     override def reads(json: JsValue) = JsSuccess(AssetLog(
       (json \ "ASSET_ID").as[Long],
       (json \ "CREATED").as[Timestamp],
@@ -96,7 +97,7 @@ object conversions {
     override def writes(log: AssetLog) = JsObject(Seq(
       "ID" -> Json.toJson(log.id),
       "ASSET_TAG" -> Json.toJson(Asset.findById(log.asset_id).map(_.tag).getOrElse("Unknown")),
-      "CREATED" -> Json.toJson(log.created),
+      "CREATED" -> Json.toJson(df.format(log.created)),
       "CREATED_BY" -> Json.toJson(log.created_by),
       "FORMAT" -> Json.toJson(log.format.toString),
       "SOURCE" -> Json.toJson(log.source.toString),

--- a/app/collins/reflection/MethodHelper.scala
+++ b/app/collins/reflection/MethodHelper.scala
@@ -60,7 +60,7 @@ trait MethodHelper extends MethodArguments with MethodReturnType {
   protected def handleFailure(msg: String) {
     if (chattyFailures) {
       logger.error(msg)
-      SystemTattler.safeError(msg)
+      SystemTattler.error(msg)
     }
   }
 }

--- a/app/collins/reflection/MethodHelper.scala
+++ b/app/collins/reflection/MethodHelper.scala
@@ -4,7 +4,7 @@ import java.lang.reflect.Method
 
 import play.api.Logger
 
-import collins.util.SystemTattler
+import collins.util.InternalTattler
 
 trait MethodHelper extends MethodArguments with MethodReturnType {
 
@@ -60,7 +60,7 @@ trait MethodHelper extends MethodArguments with MethodReturnType {
   protected def handleFailure(msg: String) {
     if (chattyFailures) {
       logger.error(msg)
-      SystemTattler.error(msg)
+      InternalTattler.system(msg)
     }
   }
 }

--- a/app/collins/util/config/Configurable.scala
+++ b/app/collins/util/config/Configurable.scala
@@ -66,7 +66,7 @@ trait Configurable extends ConfigAccessor with AppConfig { self =>
         val msg = "Reference configuration %s not found or invalid: %s".format(
           refFilename, e.getMessage
         )
-        SystemTattler.safeError(msg)
+        SystemTattler.error(msg)
         logger.error(msg, e)
         referenceConfig = None
     }
@@ -113,7 +113,7 @@ trait Configurable extends ConfigAccessor with AppConfig { self =>
           val msg = "Error validating configuration for %s: %s".format(
             getClass.getName, e.getMessage
           )
-          SystemTattler.safeError(msg)
+          SystemTattler.error(msg)
           logger.error(msg, e)
           self.underlying = savedConfig
           throw e
@@ -121,7 +121,7 @@ trait Configurable extends ConfigAccessor with AppConfig { self =>
     } catch {
       case e: Throwable =>
         val msg = "Exception in mergeReferenceAndSave: %s".format(e.getMessage)
-        SystemTattler.safeError(msg)
+        SystemTattler.error(msg)
         logger.error(msg, e)
         throw e
     }

--- a/app/collins/util/config/Configurable.scala
+++ b/app/collins/util/config/Configurable.scala
@@ -6,7 +6,7 @@ import play.api.Logger
 
 import com.typesafe.config.ConfigFactory
 
-import collins.util.SystemTattler
+import collins.util.InternalTattler
 
 trait Configurable extends ConfigAccessor with AppConfig { self =>
 
@@ -66,7 +66,7 @@ trait Configurable extends ConfigAccessor with AppConfig { self =>
         val msg = "Reference configuration %s not found or invalid: %s".format(
           refFilename, e.getMessage
         )
-        SystemTattler.error(msg)
+        InternalTattler.system(msg)
         logger.error(msg, e)
         referenceConfig = None
     }
@@ -113,7 +113,7 @@ trait Configurable extends ConfigAccessor with AppConfig { self =>
           val msg = "Error validating configuration for %s: %s".format(
             getClass.getName, e.getMessage
           )
-          SystemTattler.error(msg)
+          InternalTattler.system(msg)
           logger.error(msg, e)
           self.underlying = savedConfig
           throw e
@@ -121,7 +121,7 @@ trait Configurable extends ConfigAccessor with AppConfig { self =>
     } catch {
       case e: Throwable =>
         val msg = "Exception in mergeReferenceAndSave: %s".format(e.getMessage)
-        SystemTattler.error(msg)
+        InternalTattler.system(msg)
         logger.error(msg, e)
         throw e
     }

--- a/app/collins/util/plugins/Maintenance.scala
+++ b/app/collins/util/plugins/Maintenance.scala
@@ -7,9 +7,9 @@ import collins.models.State
 import collins.models.Status
 
 object Maintenance {
-  def toMaintenance(asset: Asset, reason: String, state: State, user: Option[User]): Boolean = {
+  def toMaintenance(asset: Asset, reason: String, state: State, lifeCycle: AssetLifecycle): Boolean = {
     if (canTransitionToMaintenance(asset)) {
-      AssetLifecycle.updateAssetStatus(asset, Status.Maintenance, Some(state), reason, user) match {
+      lifeCycle.updateAssetStatus(asset, Status.Maintenance, Some(state), reason) match {
         case Left(e) => false
         case _ => true
       }
@@ -18,9 +18,9 @@ object Maintenance {
     }
   }
 
-  def fromMaintenance(asset: Asset, reason: String, status: String, state: State, user: Option[User]): Boolean = {
+  def fromMaintenance(asset: Asset, reason: String, status: String, state: State, lifeCycle: AssetLifecycle): Boolean = {
     if (canTransitionFromMaintenance(asset)) {
-      AssetLifecycle.updateAssetStatus(asset, Status.findByName(status), Some(state), reason, user) match {
+      lifeCycle.updateAssetStatus(asset, Status.findByName(status), Some(state), reason) match {
         case Left(e) => false
         case _ => true
       }

--- a/app/collins/util/plugins/Maintenance.scala
+++ b/app/collins/util/plugins/Maintenance.scala
@@ -1,14 +1,15 @@
 package collins.util.plugins
 
+import collins.models.User
 import collins.models.Asset
 import collins.models.AssetLifecycle
 import collins.models.State
 import collins.models.Status
 
 object Maintenance {
-  def toMaintenance(asset: Asset, reason: String, state: State): Boolean = {
+  def toMaintenance(asset: Asset, reason: String, state: State, user: Option[User]): Boolean = {
     if (canTransitionToMaintenance(asset)) {
-      AssetLifecycle.updateAssetStatus(asset, Status.Maintenance, Some(state), reason) match {
+      AssetLifecycle.updateAssetStatus(asset, Status.Maintenance, Some(state), reason, user) match {
         case Left(e) => false
         case _ => true
       }
@@ -17,9 +18,9 @@ object Maintenance {
     }
   }
 
-  def fromMaintenance(asset: Asset, reason: String, status: String, state: State): Boolean = {
+  def fromMaintenance(asset: Asset, reason: String, status: String, state: State, user: Option[User]): Boolean = {
     if (canTransitionFromMaintenance(asset)) {
-      AssetLifecycle.updateAssetStatus(asset, Status.findByName(status), Some(state), reason) match {
+      AssetLifecycle.updateAssetStatus(asset, Status.findByName(status), Some(state), reason, user) match {
         case Left(e) => false
         case _ => true
       }

--- a/app/views/admin/logs.scala.html
+++ b/app/views/admin/logs.scala.html
@@ -5,11 +5,11 @@
   <div class="col-md-12">
     <script type="text/javascript">
       var logDataCols = [
-        {"mDataProp": "CREATED", "sWidth": "20%"},
-        {"mDataProp": "SOURCE", "sWidth": "10%", "bSortable": false},
-        {"mDataProp": "ASSET_TAG", "sWidth": "15%"},
+        {"mDataProp": "CREATED", "sWidth": "15%"},
+        {"mDataProp": "SOURCE", "sWidth": "5%", "bSortable": false},
+        {"mDataProp": "ASSET_TAG", "sWidth": "10%"},
         {"mDataProp": "TYPE", "sWidth": "10%", "bSortable": false},
-        {"mDataProp": "MESSAGE", "sWidth": "45%", "bSortable": false}
+        {"mDataProp": "MESSAGE", "sWidth": "60%", "bSortable": false}
       ];
     </script>
     <div class="page-header">

--- a/app/views/asset/show_logs.scala.html
+++ b/app/views/asset/show_logs.scala.html
@@ -6,11 +6,13 @@
   <h3>Logs <small>Messages logged on this asset</small></h3>
   <script type="text/javascript">
     var logDataCols = [
-      {"mDataProp": "CREATED", "sWidth": "20%"},
-      {"mDataProp": "SOURCE", "sWidth": "10%", "bSortable": false},
-      {"mDataProp": "TYPE", "sWidth": "15%", "bSortable": false},
-      {"mDataProp": "MESSAGE", "sWidth": "55%", "bSortable": false}
+      {"mDataProp": "CREATED", "sWidth": "15%"},
+      {"mDataProp": "CREATED_BY", "sWidth": "5%", "bSortable": false},
+      {"mDataProp": "SOURCE", "sWidth": "5%", "bSortable": false},
+      {"mDataProp": "TYPE", "sWidth": "10%", "bSortable": false},
+      {"mDataProp": "MESSAGE", "sWidth": "65%", "bSortable": false}
     ];
+        
     var logDataLevels = [
       "NOTE", "EMERGENCY", "ALERT", "CRITICAL", "ERROR", "WARNING"
     ];
@@ -23,6 +25,7 @@
     <thead>
       <tr>
         <th>Date</th>
+        <th>User</th>
         <th>Source</th>
         <th>Level</th>
         <th>Message</th>
@@ -33,6 +36,7 @@
     <tfoot>
       <tr>
         <th>Date</th>
+        <th>User</th>
         <th>Source</th>
         <th>Level</th>
         <th>Message</th>

--- a/conf/evolutions/collins/13.sql
+++ b/conf/evolutions/collins/13.sql
@@ -1,0 +1,9 @@
+# --- Include created by field in asset log
+
+# --- !Ups
+
+ALTER TABLE asset_log ADD COLUMN created_by CHAR(256) NOT NULL DEFAULT '';
+
+# --- !Downs
+
+ALTER TABLE asset_log drop COLUMN created_by;

--- a/test/collins/controllers/ControllerSpec.scala
+++ b/test/collins/controllers/ControllerSpec.scala
@@ -1,6 +1,9 @@
 package collins.controllers
 
-import collins.models.{User, UserImpl}
+import collins.models.User
+import collins.models.UserImpl
+import collins.models.logs.LogSource
+
 import play.api.mvc.RequestHeader
 import play.api.mvc.Action
 import play.api.mvc.Results
@@ -11,6 +14,7 @@ import play.twirl.api.Txt
 trait ControllerSpec {
   def getApi(user: Option[User]) = new Api with SecureController {
     override def authenticate(request: RequestHeader) = user
+    override def logSource = LogSource.User
     override def onUnauthorized = Action { req =>
       Results.Unauthorized(Txt("Invalid username/password specified"))
     }

--- a/test/collins/models/AssetLogSpec.scala
+++ b/test/collins/models/AssetLogSpec.scala
@@ -111,7 +111,7 @@ class AssetLogSpec extends mutable.Specification {
     def message_type = 6 // Informational
     def asset = Asset.findById(1).get
     def message = "Automatically created by database migration"
-    def newLog = AssetLog.alert(asset, "Spec error message", format, source)
+    def newLog = AssetLog.alert(asset, "tumblr", "Spec error message", format, source)
   }
 
 }

--- a/test/collins/models/AssetLogSpec.scala
+++ b/test/collins/models/AssetLogSpec.scala
@@ -100,7 +100,7 @@ class AssetLogSpec extends mutable.Specification {
     def msg = "Hello World"
     def format = LogFormat.PlainText
     def source = LogSource.Internal
-    def newLog = AssetLog.alert(asset, msg, format, source)
+    def newLog = AssetLog.alert(asset, "tumblr", msg, format, source)
   }
 
   trait concretelog extends WithApplication {
@@ -113,6 +113,5 @@ class AssetLogSpec extends mutable.Specification {
     def message = "Automatically created by database migration"
     def newLog = AssetLog.alert(asset, "Spec error message", format, source)
   }
-
 
 }


### PR DESCRIPTION
    Previously tattler log source selection was arbitrary, i.e. depends
    on the type of tattler in use. An api call can use user source or
    api source for tattling. Provide a standard means that ensures
    correctness of tattler source (By use SecureController).

    Secure Controller is aware of whether it is operating as Web or
    API. In addition, capture the user causing the tattle in a dedicated
    field on asset log instead of as part of the message. (Schema change)

    Also updated the log views to include the user field and
    formatted the date a little better.

This PR is into `bhaskar-cache-ectomy` as it builds off of changes on that.