### PR TITLE
Changes to search bar

### DIFF
--- a/app/views/help.scala.html
+++ b/app/views/help.scala.html
@@ -24,6 +24,7 @@
     <ul id="sidenav" class="nav nav-list">
       <li><a href="#support"><i class="glyphicon glyphicon-chevron-right"></i><strong>Support</strong></a></li>
       <li><a href="#documentation">Collins Documentation</a></li>
+      <li><a href="#cql">Collins Query Language</a></li>
       <li><a href="#mailingList">Mailing List</a></li>
       <li><a href="#supportTicket">Github Issues</a></li>
       <li><a href="#ipmi"><i class="glyphicon glyphicon-chevron-right"></i><strong>IPMI</strong></a></li>
@@ -48,6 +49,14 @@
 
         <p>
           There is comprehensive API, Configuration, and other documentation available at <a href="http://tumblr.github.com/collins/">http://tumblr.github.com/collins/</a>
+        </p>
+      </div>
+
+      <div id="cql" class="subsection">
+        <h3>Collins Query Language</h3>
+
+        <p>
+          Help on Collins Query language is available under the <a href="http://tumblr.github.io/collins/recipes.html#cql">recipes section</a> in the documentation
         </p>
       </div>
 

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -40,15 +40,17 @@
 
         <div class="collapse navbar-collapse">
           <ul class="nav navbar-nav navbar-right">
-            <li>
-              @form(collins.app.routes.Resources.find(0,50,"DESC","and"), 'class -> "navbar-form navbar-left", 'role -> "search") {
-              <div class="input-group navbar-right">
-                <span class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span>
-                <input type="text" autofocus="autofocus" autocomplete="off" placeholder="Asset tag / CQL" name="query" class="form-control">
-                <span class="input-group-addon"><a href="@collins.app.routes.HelpPage.index("cql")"><i class="glyphicon glyphicon-question-sign icon-white"></i></a></span>
-              </div>
+            @if(req.path != "/") {
+              <li>
+                @form(collins.app.routes.Resources.find(0,50,"DESC","and"), 'class -> "navbar-form navbar-left", 'role -> "search") {
+                <div class="input-group navbar-right">
+                  <span class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span>
+                  <input type="text" autofocus="autofocus" autocomplete="off" placeholder="Asset tag / CQL" name="query" class="form-control">
+                  <span class="input-group-addon"><a href="@collins.app.routes.HelpPage.index("cql")"><i class="glyphicon glyphicon-question-sign icon-white"></i></a></span>
+                </div>
+              }
+              </li>
             }
-            </li>
 	        @User.fromMap(req.session.data).map { u =>
 	          @if(Permissions.please(u, Permissions.AssetApi.CreateAsset)) {
 	          <li class="dropdown @{if (req.path contains "/asset/create") "active" }">

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -37,32 +37,38 @@
           </button>
           <a class="navbar-brand" href="@collins.app.routes.Resources.index">Collins</a>
         </div>
-        @form(collins.app.routes.Resources.find(0,50,"DESC","and"), 'class -> "form-horizontal") {
+        <ul class="nav navbar-nav">
+          @User.fromMap(req.session.data).map { u =>
+            @if(Permissions.please(u, Permissions.AssetApi.CreateAsset)) {
+            <li class="dropdown @{if (req.path contains "/asset/create") "active" }">
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown">Create <b class="caret"></b></a>
+              <ul class="dropdown-menu">
+                @AssetType.find().filter(_.name != "SERVER_NODE").map { t =>
+                  <li><a href="@collins.app.routes.Resources.displayCreateForm(t.name)">@t.label</a></li>
+                }
+              </ul>
+            </li>
+            }
+            @if(Permissions.please(u, Permissions.AssetLogApi.GetAll)) {
+              <li class="@{if (req.path == collins.controllers.routes.Admin.logs.toString) "active" }"><a href="@collins.controllers.routes.Admin.logs">Logging</a></li>
+            }
+          }
+        </ul>
+        <div class="col-sm-8 col-md-8">
+          @form(collins.app.routes.Resources.find(0,50,"DESC","and"), 'class -> "navbar-form navbar-right form-horizontal") {
+          <div class="input-group">
+            <input type="text" autofocus="autofocus" autocomplete="off" placeholder="Enter search using CQL" name="query" class="form-control">
+            <span style="width: 1%;" class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span>
+          </div>
+          }
+        </div>
+
         <div class="navbar-collapse collapse navbar-right">
           <ul class="nav navbar-nav">
-            <li class="@{if (req.path == collins.app.routes.Resources.index.toString) "active" }">
-              <input type="text" class="form-control" placeholder="Search Asset Tag" name="tag">
-            </li>
-            @User.fromMap(req.session.data).map { u =>
-              @if(Permissions.please(u, Permissions.AssetLogApi.GetAll)) {
-                <li class="@{if (req.path == collins.controllers.routes.Admin.logs.toString) "active" }"><a href="@collins.controllers.routes.Admin.logs">Logging</a></li>
-              }
-              @if(Permissions.please(u, Permissions.AssetApi.CreateAsset)) {
-              <li class="dropdown @{if (req.path contains "/asset/create") "active" }">
-                <a href="#" class="dropdown-toggle" data-toggle="dropdown">Create <b class="caret"></b></a>
-                <ul class="dropdown-menu">
-                  @AssetType.find().filter(_.name != "SERVER_NODE").map { t =>
-                    <li><a href="@collins.app.routes.Resources.displayCreateForm(t.name)">@t.label</a></li>
-                  }
-                </ul>
-              </li>
-              }
-            }
-            <li><a href="@collins.app.routes.HelpPage.index("default")"><i class="glyphicon glyphicon-question-sign icon-white"></i></a></li>
             <li><a href="@collins.controllers.routes.Application.logout">Logout</a></li>
+            <li><a href="@collins.app.routes.HelpPage.index("default")"><i class="glyphicon glyphicon-question-sign icon-white"></i></a></li>
           </ul>
         </div>
-      }
       </div>
     </nav>
     } else {

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -37,34 +37,33 @@
           </button>
           <a class="navbar-brand" href="@collins.app.routes.Resources.index">Collins</a>
         </div>
-        <ul class="nav navbar-nav">
-          @User.fromMap(req.session.data).map { u =>
-            @if(Permissions.please(u, Permissions.AssetApi.CreateAsset)) {
-            <li class="dropdown @{if (req.path contains "/asset/create") "active" }">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown">Create <b class="caret"></b></a>
-              <ul class="dropdown-menu">
-                @AssetType.find().filter(_.name != "SERVER_NODE").map { t =>
-                  <li><a href="@collins.app.routes.Resources.displayCreateForm(t.name)">@t.label</a></li>
-                }
-              </ul>
-            </li>
-            }
-            @if(Permissions.please(u, Permissions.AssetLogApi.GetAll)) {
-              <li class="@{if (req.path == collins.controllers.routes.Admin.logs.toString) "active" }"><a href="@collins.controllers.routes.Admin.logs">Logging</a></li>
-            }
-          }
-        </ul>
-        <div class="col-sm-8 col-md-8">
-          @form(collins.app.routes.Resources.find(0,50,"DESC","and"), 'class -> "navbar-form navbar-right form-horizontal") {
-          <div class="input-group">
-            <input type="text" autofocus="autofocus" autocomplete="off" placeholder="Search using an Asset tag or Collins Query" name="query" class="form-control">
-            <span style="width: 1%;" class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span>
-          </div>
-          }
-        </div>
 
-        <div class="navbar-collapse collapse navbar-right">
-          <ul class="nav navbar-nav">
+        <div class="collapse navbar-collapse">
+          <ul class="nav navbar-nav navbar-right">
+            <li>
+              @form(collins.app.routes.Resources.find(0,50,"DESC","and"), 'class -> "navbar-form navbar-left", 'role -> "search") {
+              <div class="input-group navbar-right">
+                <span class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span>
+                <input type="text" autofocus="autofocus" autocomplete="off" placeholder="Asset tag / CQL" name="query" class="form-control">
+                <span class="input-group-addon"><a href="@collins.app.routes.HelpPage.index("cql")"><i class="glyphicon glyphicon-question-sign icon-white"></i></a></span>
+              </div>
+            }
+            </li>
+	        @User.fromMap(req.session.data).map { u =>
+	          @if(Permissions.please(u, Permissions.AssetApi.CreateAsset)) {
+	          <li class="dropdown @{if (req.path contains "/asset/create") "active" }">
+	            <a href="#" class="dropdown-toggle" data-toggle="dropdown">Create <b class="caret"></b></a>
+	            <ul class="dropdown-menu">
+	              @AssetType.find().filter(_.name != "SERVER_NODE").map { t =>
+	                <li><a href="@collins.app.routes.Resources.displayCreateForm(t.name)">@t.label</a></li>
+	              }
+	            </ul>
+              </li>
+	          }
+	          @if(Permissions.please(u, Permissions.AssetLogApi.GetAll)) {
+	            <li class="@{if (req.path == collins.controllers.routes.Admin.logs.toString) "active" }"><a href="@collins.controllers.routes.Admin.logs">Logging</a></li>
+	          }
+	        }
             <li><a href="@collins.controllers.routes.Application.logout">Logout</a></li>
             <li><a href="@collins.app.routes.HelpPage.index("default")"><i class="glyphicon glyphicon-question-sign icon-white"></i></a></li>
           </ul>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -57,7 +57,7 @@
         <div class="col-sm-8 col-md-8">
           @form(collins.app.routes.Resources.find(0,50,"DESC","and"), 'class -> "navbar-form navbar-right form-horizontal") {
           <div class="input-group">
-            <input type="text" autofocus="autofocus" autocomplete="off" placeholder="Enter search using CQL" name="query" class="form-control">
+            <input type="text" autofocus="autofocus" autocomplete="off" placeholder="Search using an Asset tag or Collins Query" name="query" class="form-control">
             <span style="width: 1%;" class="input-group-addon"><i class="glyphicon glyphicon-search"></i></span>
           </div>
           }

--- a/test/collins/controllers/FormsSpec.scala
+++ b/test/collins/controllers/FormsSpec.scala
@@ -1,0 +1,24 @@
+package collins.controllers
+
+import org.specs2._
+import specification._
+
+import collins.controllers.forms._
+
+class FormsSpec extends mutable.Specification {
+  
+  "Solr expression format should correctly bind a valid query" in {
+    val result = SolrExpressionFormat.bind("query", Map("query" -> "tag=TRQ* AND name=SomeThing"))
+    result must beRight
+  }
+  
+  "Solr expression format should return errors on invalid query" in {
+    val result = SolrExpressionFormat.bind("query", Map("query" -> "!A#!!"))
+    result must beLeft
+  }
+  
+  "Solr expression format must return valid query by interpreting as a tag" in {
+    val result = SolrExpressionFormat.bind("query", Map("query" -> "TRQ12"))
+    result must beRight
+  }
+}


### PR DESCRIPTION
Some improvements to the search bar.

(a) Search can be done either using a CQL or tag
(b) Some minor changes to the header (search bar is bigger). Feature header items are to the left, only help and logout are on the right

Forms formatter (the code that converts) a string to a CQLQuery or SolrExpression (in the controller layer, not the CQL parser), now attempt to create a valid query string if the user provided string does not parse. This is done in exactly 1 case, if the provided string passes the asset tag constrains.

i.e. searching for `A1000` in the search bar or the home landing page text area will return the asset instead of returning an error.

![image](https://cloud.githubusercontent.com/assets/110992/8619687/01c2b532-26e7-11e5-8f40-e38b45c2ab65.png)

@MaximeDevalland @Primer42 @defect @byxorna 

Maxime, while the asset tag was good, I felt it did not provide as much utility as it could with CQL. This will support the tag search in additional to CQL, thoughts?
