### PR TITLE
Ensure only 1 instance of auth provider is ever created

### DIFF
--- a/app/collins/util/security/AuthenticationProvider.scala
+++ b/app/collins/util/security/AuthenticationProvider.scala
@@ -8,7 +8,7 @@ import collins.cache.GuavaCacheFactory
 
 trait AuthenticationProvider {
   protected val logger = Logger.logger
-  def authType: Array[String]
+  def authType: List[String]
   def authenticate(username: String, password: String): Option[User]
 }
 
@@ -18,7 +18,7 @@ object AuthenticationProvider {
   lazy private val permissionsCache =   
     GuavaCacheFactory.create(AuthenticationProviderConfig.permissionsCacheSpecification, PermissionsLoader())
 
-  def get(types: Array[String]): AuthenticationProvider = {
+  def get(types: List[String]): AuthenticationProvider = {
     new MixedAuthenticationProvider(types)
   }
 

--- a/app/collins/util/security/AuthenticationProviderConfig.scala
+++ b/app/collins/util/security/AuthenticationProviderConfig.scala
@@ -13,7 +13,7 @@ object AuthenticationProviderConfig extends Configurable {
   def adminGroup = getStringSet("adminGroup").map(_.toLowerCase)
   def permissionsCacheSpecification = getString("permissionsCacheSpecification", "expireAfterWrite=30s")
   def permissionsFile = getString("permissionsFile")(ConfigValue.Required).get
-  def authType = getString("type", "default").split(",").map(_.trim.toLowerCase)
+  def authType = getString("type", "default").split(",").toList.map(_.trim.toLowerCase)
 
   override protected def validateConfig() {
     File.requireFileIsReadable(permissionsFile)

--- a/app/collins/util/security/FileAuthenticationProvider.scala
+++ b/app/collins/util/security/FileAuthenticationProvider.scala
@@ -10,7 +10,7 @@ import collins.cache.GuavaCacheFactory
 class FileAuthenticationProvider() extends AuthenticationProvider {
 
   def userfile = FileAuthenticationProviderConfig.userfile
-  override val authType = Array("file")
+  override val authType = List("file")
 
   private lazy val userCache = GuavaCacheFactory.create(FileAuthenticationProviderConfig.cacheSpecification, FileUserLoader())
 

--- a/app/collins/util/security/LdapAuthenticationProvider.scala
+++ b/app/collins/util/security/LdapAuthenticationProvider.scala
@@ -16,7 +16,7 @@ import com.google.common.cache.CacheLoader
 class LdapAuthenticationProvider extends AuthenticationProvider {
 
   val config = LdapAuthenticationProviderConfig
-  override val authType = Array("ldap")
+  override val authType = List("ldap")
 
   // LDAP values
   def host = config.host
@@ -39,7 +39,7 @@ class LdapAuthenticationProvider extends AuthenticationProvider {
   type Credentials = Tuple2[String,String]
   lazy val cache = GuavaCacheFactory.create(config.cacheSpecification, new CacheLoader[Credentials, Option[User]] {
     override def load(creds: Credentials): Option[User] = {
-      nativeAuthenticate(creds._1, creds._2)
+      nativeAuthenticate(creds)
     } 
   })
 
@@ -131,7 +131,8 @@ class LdapAuthenticationProvider extends AuthenticationProvider {
     cache.get((username, password))
   }
   
-  private def nativeAuthenticate(username:String, password: String): Option[User] = {
+  private def nativeAuthenticate(creds: Credentials): Option[User] = {
+    val (username, password) = creds
     logger.info("Loading user %s from backend".format(username))
 
     getInitialContext().flatMap (withCtxt(_) { ctx =>

--- a/app/collins/util/security/MixedAuthenticationProvider.scala
+++ b/app/collins/util/security/MixedAuthenticationProvider.scala
@@ -15,7 +15,7 @@ class AuthenticationException(msg: String) extends Exception(msg)
 /**
  * Provides authentication by a variety of methods and caching logic (implements decorator pattern)
  */
-class MixedAuthenticationProvider(types: Array[String]) extends AuthenticationProvider {
+class MixedAuthenticationProvider(types: List[String]) extends AuthenticationProvider {
   
   private val providers = types.map({
      case "default" => {

--- a/app/collins/util/security/MockAuthenticationProvider.scala
+++ b/app/collins/util/security/MockAuthenticationProvider.scala
@@ -4,7 +4,7 @@ import collins.models.User
 import collins.models.UserImpl
 
 class MockAuthenticationProvider extends AuthenticationProvider {
-  override val authType = Array("default")
+  override val authType = List("default")
 
   val users = Map(
     "blake" -> UserImpl("blake", "admin:first", Set("engineering","Infra","ops"), 1024, false),

--- a/test/collins/util/security/AuthenticationProviderSpec.scala
+++ b/test/collins/util/security/AuthenticationProviderSpec.scala
@@ -19,7 +19,7 @@ object AuthenticationProviderSpec extends Specification with collins.ResourceFin
     "work with file based auth" in new WithApplication(FakeApplication(additionalConfiguration=Map(
         "authentication.file.userfile" -> authFile.getAbsolutePath
       ))) {
-      val provider = AuthenticationProvider.get(Array("file"))
+      val provider = AuthenticationProvider.get(List("file"))
 
       val users = Seq(
         ("blake", "password123", Set("engineering")),

--- a/test/collins/util/security/AuthenticationProviderSpec.scala
+++ b/test/collins/util/security/AuthenticationProviderSpec.scala
@@ -6,6 +6,7 @@ import org.specs2.mutable._
 import java.io.File
 import play.api.test.WithApplication
 import play.api.test.FakeApplication
+import play.api.Play
 
 object AuthenticationProviderSpec extends Specification with collins.ResourceFinder {
 
@@ -16,25 +17,39 @@ object AuthenticationProviderSpec extends Specification with collins.ResourceFin
       provider.authenticate("no", "suchuser") must beNone
     }
     val authFile = findResource("htpasswd_users")
-    "work with file based auth" in new WithApplication(FakeApplication(additionalConfiguration=Map(
-        "authentication.file.userfile" -> authFile.getAbsolutePath
-      ))) {
+    "work with file based auth" in new WithApplication(FakeApplication(additionalConfiguration = Map(
+      "authentication.file.userfile" -> authFile.getAbsolutePath))) {
       val provider = AuthenticationProvider.get(List("file"))
 
       val users = Seq(
         ("blake", "password123", Set("engineering")),
-        ("testuser", "FizzBuzzAbc", Set("ny","also"))
-      )
+        ("testuser", "FizzBuzzAbc", Set("ny", "also")))
 
-      users.foreach { case(username,password,roles) =>
-        val user = provider.authenticate(username, password)
-        user must beSome[User]
-        user.get.username mustEqual username
-        user.get.password mustNotEqual password
-        user.get.isAuthenticated must beTrue
-        user.get.roles mustEqual roles
+      users.foreach {
+        case (username, password, roles) =>
+          val user = provider.authenticate(username, password)
+          user must beSome[User]
+          user.get.username mustEqual username
+          user.get.password mustNotEqual password
+          user.get.isAuthenticated must beTrue
+          user.get.roles mustEqual roles
       }
       provider.authenticate("blake", "abbazabba") must beNone
+    }
+  }
+}
+
+object GlobalAuthenticationAccessorSpec extends Specification with collins.ResourceFinder {
+  "Global object" should {
+    val authFile = findResource("htpasswd_users")
+    "have only a singleton for auth provider" in new WithApplication(FakeApplication(additionalConfiguration = Map(
+      "authentication.file.userfile" -> authFile.getAbsolutePath))) {
+      val authAccessor = Play.current.global.asInstanceOf[AuthenticationAccessor]
+      val provider = authAccessor.getAuthentication()
+      val another = authAccessor.getAuthentication()
+      provider.authType mustEqual List("default")
+      another.authType mustEqual List("default")
+      provider must be equalTo another
     }
   }
 }


### PR DESCRIPTION
check on provider types has been failing causing a new instance
to be created every time. Switching to List (immutable) addresses
the issue.

Summary:
scala> List("ldap") == List("ldap")
res0: Boolean = true

scala> List("ldap") != List("ldap")
res1: Boolean = false

scala> Array("ldap") != Array("ldap")
res2: Boolean = true

scala> Array("ldap") == Array("ldap")
res3: Boolean = false

@byxorna @Primer42 @defect @roymarantz 