### PR TITLE
Reintroduce caching into models

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -23,6 +23,7 @@ import collins.util.security.AuthenticationAccessor
 import collins.util.security.AuthenticationProvider
 import collins.util.security.AuthenticationProviderConfig
 
+import collins.models.cache.Cache
 import collins.logging.LoggingHelper
 import collins.util.config.Registry
 import collins.solr.SolrHelper
@@ -39,6 +40,7 @@ object Global extends GlobalSettings with AuthenticationAccessor with CryptoAcce
 
   override def onStart(app: Application) {
     Registry.setupRegistry(app)
+    Cache.setupCache()
     setAuthentication(AuthenticationProvider.get(AuthenticationProviderConfig.authType))
     setCryptoKey(CryptoConfig.key)
     LoggingHelper.setupLogging(app)
@@ -46,7 +48,7 @@ object Global extends GlobalSettings with AuthenticationAccessor with CryptoAcce
     MetricsReporter.setupMetrics()
     Callback.setupCallbacks()
   }
-  
+
   override def onStop(app: Application) {
     DB.shutdown()
     Registry.terminateRegistry()

--- a/app/collins/cache/CacheConfig.scala
+++ b/app/collins/cache/CacheConfig.scala
@@ -1,0 +1,21 @@
+package collins.cache
+
+import com.google.common.cache.CacheBuilderSpec
+
+import collins.util.config.Configurable
+
+object CacheConfig extends Configurable {
+
+  override val namespace = "cache"
+  override val referenceConfigFilename = "cache_reference.conf"
+
+  def enabled = getBoolean("enabled", true)
+  def specification = getString("specification", "maximumSize=10000,expireAfterWrite=10s")
+
+  override protected def validateConfig() {
+    if (enabled) {
+      logger.debug("Validating domain model cache specification")
+      CacheBuilderSpec.parse(specification)
+    }
+  }
+}

--- a/app/collins/cache/CacheConfig.scala
+++ b/app/collins/cache/CacheConfig.scala
@@ -10,7 +10,7 @@ object CacheConfig extends Configurable {
   override val referenceConfigFilename = "cache_reference.conf"
 
   def enabled = getBoolean("enabled", true)
-  def specification = getString("specification", "maximumSize=10000,expireAfterWrite=10s")
+  def specification = getString("specification", "maximumSize=10000,expireAfterWrite=10s,recordStats")
 
   override protected def validateConfig() {
     if (enabled) {

--- a/app/collins/cache/GuavaCacheFactory.scala
+++ b/app/collins/cache/GuavaCacheFactory.scala
@@ -3,6 +3,7 @@ package collins.cache
 import com.google.common.cache.CacheBuilder
 import com.google.common.cache.CacheLoader
 import com.google.common.cache.LoadingCache
+import com.google.common.cache.{ Cache => BasicCache }
 
 /**
  * Creates an instance of Guava cache with the provided specification and cache loader.
@@ -11,4 +12,6 @@ object GuavaCacheFactory {
   def create[K <: AnyRef, V <: AnyRef](specification: String, loader: => CacheLoader[K, V]): LoadingCache[K, V] =
     CacheBuilder.from(specification)
       .build(loader)
+
+  def create[K <: AnyRef, V <: AnyRef](specification: String): BasicCache[K, V] = CacheBuilder.from(specification).build()
 }

--- a/app/collins/callbacks/CallbackMatcher.scala
+++ b/app/collins/callbacks/CallbackMatcher.scala
@@ -46,7 +46,7 @@ case class CallbackMatcher(conditional: MatchConditional, fn: PropertyChangeEven
     val states = conditional.states.toSet
     val value = Option(fn(pce))
     value.filter(_.isInstanceOf[AssetView]).map(_.asInstanceOf[AssetView]).map { v =>
-      State.findById(v.state).map { state =>
+      State.findById(v.stateId).map { state =>
         states.map(_.toUpperCase).contains(state.name.toUpperCase)
       }.getOrElse(false)
     }.getOrElse(true)

--- a/app/collins/controllers/Admin.scala
+++ b/app/collins/controllers/Admin.scala
@@ -1,5 +1,7 @@
 package collins.controllers
 
+import collins.models.cache.Cache
+
 import collins.solr.Solr
 import collins.util.Stats
 
@@ -15,7 +17,16 @@ object Admin extends SecureWebController {
     Ok(html.admin.logs())
   }(Permissions.AssetLogApi.GetAll)
 
-  def populateSolr = SecureAction {implicit req => 
+  def cache = SecureAction { implicit req =>
+    Ok(html.admin.cache(Cache.stats))
+  }(Permissions.Admin.Cache)
+
+  def clearCache = SecureAction { implicit req =>
+    Cache.clear()
+    Redirect(routes.Admin.cache)
+  }(Permissions.Admin.ClearCache)
+
+  def populateSolr = SecureAction { implicit req =>
     Solr.populate()
     Redirect(collins.app.routes.Resources.index).flashing("error" -> "Repopulating Solr index in the background.  May take a few minutes to complete")
   }(Permissions.Admin.ClearCache)

--- a/app/collins/controllers/IpmiApi.scala
+++ b/app/collins/controllers/IpmiApi.scala
@@ -34,7 +34,7 @@ trait IpmiApi {
         val g = IpAddress.toLong(gateway.get)
         val n = IpAddress.toLong(netmask.get)
         val p = IpmiInfo.encryptPassword(password.get)
-        IpmiInfo(asset.getId, username.get, p, g, a, n)
+        IpmiInfo(asset.id, username.get, p, g, a, n)
       }
     }
   }

--- a/app/collins/controllers/Permissions.scala
+++ b/app/collins/controllers/Permissions.scala
@@ -32,6 +32,7 @@ object Permissions {
   object Admin extends PermSpec("controllers.Admin") {
     def Spec = spec(AdminSpec)
     def Stats = spec("stats", Spec)
+    def Cache = spec("cache", Spec)
     def ClearCache = spec("clearCache", Stats)
   }
 

--- a/app/collins/controllers/actions/asset/ProvisionUtil.scala
+++ b/app/collins/controllers/actions/asset/ProvisionUtil.scala
@@ -233,13 +233,13 @@ trait Provisions extends ProvisionUtil with AssetAction { self: SecureAction =>
     val slId = SoftLayer.softLayerId(asset).get
     if (attribs.nonEmpty) {
       val lifeCycle = new AssetLifecycle(userOption(), tattler)
-      lifeCycle.updateAssetAttributes(Asset.findById(asset.getId).get, attribs)
+      lifeCycle.updateAssetAttributes(Asset.findById(asset.id).get, attribs)
     }
     
     BackgroundProcessor.send(ActivationProcessor(slId)(request)) { res =>
       processProvisionAction(res) {
         case true =>
-          val newAsset = Asset.findById(asset.getId).get
+          val newAsset = Asset.findById(asset.id).get
           Asset.partialUpdate(newAsset, None, AStatus.New.map(_.id))
           setAsset(newAsset)
           tattle("Asset successfully activated", false)
@@ -271,9 +271,9 @@ trait Provisions extends ProvisionUtil with AssetAction { self: SecureAction =>
         if (attribs.nonEmpty) {
           val lifeCycle = new AssetLifecycle(userOption(), tattler)
           lifeCycle.updateAssetAttributes(
-            Asset.findById(asset.getId).get, attribs
+            Asset.findById(asset.id).get, attribs
           )
-          setAsset(Asset.findById(asset.getId))
+          setAsset(Asset.findById(asset.id))
         }
         BackgroundProcessor.send(ProvisionerRun(pRequest)) { res =>
           processProvisionAction(res) { result =>

--- a/app/collins/controllers/actions/asset/UpdateStatusAction.scala
+++ b/app/collins/controllers/actions/asset/UpdateStatusAction.scala
@@ -107,8 +107,8 @@ case class UpdateStatusAction(
   protected def checkStateConflict(
     asset: Asset, statusOpt: Option[AssetStatus], stateOpt: Option[State]
   ): Tuple2[Option[AssetStatus],Option[State]] = {
-    val status = statusOpt.getOrElse(asset.getStatus())
-    val state = stateOpt.getOrElse(State.findById(asset.stateId).getOrElse(State.empty))
+    val status = statusOpt.getOrElse(asset.status)
+    val state = stateOpt.getOrElse(asset.state.getOrElse(State.empty))
     if (state.status == State.ANY_STATUS || state.status == status.id) {
       (None, None)
     } else {

--- a/app/collins/controllers/actions/asset/UpdateStatusAction.scala
+++ b/app/collins/controllers/actions/asset/UpdateStatusAction.scala
@@ -108,7 +108,7 @@ case class UpdateStatusAction(
     asset: Asset, statusOpt: Option[AssetStatus], stateOpt: Option[State]
   ): Tuple2[Option[AssetStatus],Option[State]] = {
     val status = statusOpt.getOrElse(asset.getStatus())
-    val state = stateOpt.getOrElse(State.findById(asset.state).getOrElse(State.empty))
+    val state = stateOpt.getOrElse(State.findById(asset.stateId).getOrElse(State.empty))
     if (state.status == State.ANY_STATUS || state.status == status.id) {
       (None, None)
     } else {

--- a/app/collins/controllers/actions/ipaddress/FindAssetByPoolAction.scala
+++ b/app/collins/controllers/actions/ipaddress/FindAssetByPoolAction.scala
@@ -26,7 +26,7 @@ case class FindAssetsByPoolAction(
   override def validate(): Validation =
     Right(ActionDataHolder(convertPoolName(pool)))
 
-  override def execute(rd: RequestDataHolder) = Future { 
+  override def execute(rd: RequestDataHolder) = Future {
     rd match {
       case ActionDataHolder(cleanPool) =>
         IpAddresses.findInPool(cleanPool) match {
@@ -35,7 +35,7 @@ case class FindAssetsByPoolAction(
               RequestDataHolder.error404("No such pool or no assets in pool")
             )
           case list =>
-            val jsList = list.map(e => Asset.findById(e.asset_id).get.toJsValue).toList
+            val jsList = list.map(e => Asset.findById(e.assetId).get.toJsValue).toList
             ResponseData(Status.Ok, JsObject(Seq("ASSETS" -> JsArray(jsList))))
         }
     }

--- a/app/collins/controllers/actions/ipaddress/UpdateAction.scala
+++ b/app/collins/controllers/actions/ipaddress/UpdateAction.scala
@@ -42,7 +42,7 @@ case class UpdateAction(
     }.getOrElse {
       if (address.isDefined && gateway.isDefined && netmask.isDefined) {
         val p = convertPoolName(pool.getOrElse(IpAddressConfig.DefaultPoolName))
-        IpAddresses(asset.getId, gateway.get, address.get, netmask.get, p)
+        IpAddresses(asset.id, gateway.get, address.get, netmask.get, p)
       } else {
         throw new Exception("If creating a new IP the address, gateway and netmask must be specified")
       }

--- a/app/collins/controllers/actions/logs/SolrFindAction.scala
+++ b/app/collins/controllers/actions/logs/SolrFindAction.scala
@@ -51,7 +51,7 @@ case class SolrFindAction(
   }
 
   protected def getLogs(adh: ActionDataHolder): Page[AssetLog] = {
-    (new AssetLogSearchQuery(adh.query, adh.params)).getPage.fold(
+    (new AssetLogSearchQuery(adh.query, adh.params)).getPage(AssetLog.findByIds(_)).fold(
       err => throw new Exception(err),
       res => res
     )

--- a/app/collins/graphs/MetricsCacheLoader.scala
+++ b/app/collins/graphs/MetricsCacheLoader.scala
@@ -4,6 +4,7 @@ import play.api.Logger
 
 import com.google.common.cache.CacheLoader
 
+import collins.models.Asset
 import collins.models.shared.PageParams
 import collins.models.shared.SortDirection
 import collins.solr.AssetDocType
@@ -43,7 +44,7 @@ case class MetricsCacheLoader() extends CacheLoader[MetricsQuery, Set[String]] {
         },
         expr => {
           val cq = AssetSearchQuery(expr, PageParams(0, 1, SortDirection.SortAsc, "TAG"))
-          cq.getPage().fold(
+          cq.getPage(Asset.findByTags(_)).fold(
             err => {
               logger.warn("Error executing CQL query: %s".format(err))
               false

--- a/app/collins/models/Asset.scala
+++ b/app/collins/models/Asset.scala
@@ -1,9 +1,30 @@
 package collins.models
 
+import java.sql.Timestamp
+import java.util.Date
+
+import play.api.libs.json.Json
+import play.api.Logger
+
+import org.squeryl.PrimitiveTypeMode._
+import org.squeryl.Schema
+import org.squeryl.annotations.Column
+import org.squeryl.annotations.Transient
+
+import collins.models.cache.Cache
 import collins.models.asset.AssetView
 import collins.models.asset.AllAttributes
 import collins.models.asset.conversions._
 import collins.models.conversions._
+import collins.models.shared.QueryLogConfig
+import collins.models.AssetSort.Type
+import collins.models.shared.SortDirection._
+import collins.models.shared.ValidatedEntity
+import collins.models.shared.AnormAdapter
+import collins.models.shared.Page
+import collins.models.shared.PageParams
+import collins.models.shared.SortDirection
+
 import collins.util.AttributeResolver
 import collins.util.LldpRepresentation
 import collins.util.LshwRepresentation
@@ -14,33 +35,13 @@ import collins.util.config.MultiCollinsConfig
 import collins.util.config.NodeclassifierConfig
 import collins.util.power.PowerUnits
 import collins.util.views.Formatter.dateFormat
+import collins.util.RemoteCollinsHost
+
+import collins.solr.AssetSearchQuery
 import collins.solr.CQLQuery
 import collins.solr.AssetDocType
-import collins.solr.AssetSearchQuery
-import collins.models.shared.QueryLogConfig
-import collins.models.AssetSort.Type
 
 import collins.validation.Pattern.isAlphaNumericString
-
-import collins.util.{MessageHelper, RemoteCollinsHost, Stats}
-
-import play.api.libs.json.Json
-import play.api.Logger
-
-import org.squeryl.PrimitiveTypeMode._
-import org.squeryl.Schema
-import org.squeryl.annotations.Column
-import org.squeryl.annotations.Transient
-
-import java.sql.Timestamp
-import java.util.Date
-
-import collins.models.shared.SortDirection._
-import collins.models.shared.ValidatedEntity
-import collins.models.shared.AnormAdapter
-import collins.models.shared.Page
-import collins.models.shared.PageParams
-import collins.models.shared.SortDirection
 
 case class Asset(tag: String, @Column("STATUS") statusId: Int, @Column("ASSET_TYPE") assetTypeId: Int,
     created: Timestamp, updated: Option[Timestamp], deleted: Option[Timestamp],
@@ -80,8 +81,8 @@ case class Asset(tag: String, @Column("STATUS") statusId: Int, @Column("ASSET_TY
   def getMetaAttribute(name: String): Option[MetaWrapper] = {
     AssetMeta.findByName(name).flatMap { meta =>
       AssetMetaValue.findByAssetAndMeta(this, meta, 1) match {
-        case Nil => None
-        case head :: Nil => Some(head)
+        case List(mw) => Some(mw)
+        case _ => None
       }
     }
   }
@@ -103,7 +104,7 @@ case class Asset(tag: String, @Column("STATUS") statusId: Int, @Column("ASSET_TY
     val nodeclassType = NodeclassifierConfig.assetType
     val instanceFinder = AssetFinder
       .empty
-      .copy ( 
+      .copy (
         assetType = Some(nodeclassType)
       )
     val nodeclassParams: ResolvedAttributes = EmptyResolvedAttributes
@@ -114,7 +115,7 @@ case class Asset(tag: String, @Column("STATUS") statusId: Int, @Column("ASSET_TY
       .collect{case a: Asset => a}
     val myMetaSeq = this.metaSeq
     //Note - we cannot use set operations because an asset may contain multiple values of the same meta
-    nodeclasses.map{n => 
+    nodeclasses.map{n =>
       val metaseq = n.filteredMetaSeq
       if (metaseq.foldLeft(true){(ok, metaval) => ok && (myMetaSeq contains metaval)}) {
         logger.debug("%s,%d".format(n.toString, metaseq.size))
@@ -141,7 +142,7 @@ case class Asset(tag: String, @Column("STATUS") statusId: Int, @Column("ASSET_TY
   def remoteHost = None
 }
 
-object Asset extends Schema with AnormAdapter[Asset] {
+object Asset extends Schema with AnormAdapter[Asset] with AssetKeys {
 
   private[this] val logger = Logger("Asset")
   override protected val createEventName = Some("asset_create")
@@ -158,6 +159,9 @@ object Asset extends Schema with AnormAdapter[Asset] {
     a.created is(indexed),
     a.updated is(indexed)
   ))
+
+  def flushCache(asset: Asset) = loggedInvalidation("flushCache", asset)
+
   object Messages extends MessageHelper("asset") {
     def intakeError[T <: AssetView](t: String, a: T) = "intake.error.%s".format(t.toLowerCase) match {
       case msg if msg == "intake.error.new" =>
@@ -203,22 +207,36 @@ object Asset extends Schema with AnormAdapter[Asset] {
       )
   }
 
-  def findById(id: Long) = inTransaction {
+  def findById(id: Long) = Cache.get(findByIdKey(id), inTransaction {
     tableDef.lookup(id)
-  }
+  })
+
   def get(a: Asset) = findById(a.id).get
 
-  def findByTags(tags: Seq[String]): List[Asset] = inTransaction {
+  // Loads assets from cache, then database if not available in cache.
+  // Asset are loaded from database using 'in' clause, and are added to cache
+  // Returns assets in the order requested, i.e. tag order in params
+  def findByTags(tags: Seq[String]) = {
     val ltags = tags.map { _.toLowerCase }
-    from(tableDef)(s =>
-      where(s.tag.toLowerCase in ltags)
-      select(s)
-    ).toList
+    val assetOpts = ltags.map { tag => tag -> Cache.get[Option[Asset]](findByTagKey(tag)) }.toMap
+    val loadedAssets = inTransaction { from(tableDef)(s =>
+      where(s.tag.toLowerCase in assetOpts.filter(_._2.isEmpty).map(_._1))
+        select (s)).map { asset => {
+          Cache.put(s"Asset.findByTag(${asset.tag.toLowerCase})", Some(asset))
+          (asset.tag.toLowerCase, asset)
+        }}.toMap
+    }
+    ltags.flatMap { tag =>
+      assetOpts(tag) match {
+        case None => loadedAssets.get(tag)
+        case Some(x)    => x
+      }
+    }
   }
-  
-  def findByTag(tag: String): Option[Asset] = inTransaction {
+
+  def findByTag(tag: String): Option[Asset] = Cache.get(findByTagKey(tag), inTransaction {
     tableDef.where(_.tag.toLowerCase === tag.toLowerCase).headOption
-  }
+  })
 
   /**
    * Finds assets across multiple collins instances.  Data for instances are
@@ -243,7 +261,7 @@ object Asset extends Schema with AnormAdapter[Asset] {
       .collect{case a: Asset => a}
       .filter{_.tag != MultiCollinsConfig.thisInstance}
     //iterate over the locations, sending requests to each one and aggregate their results
-    val remoteClients = findLocations.flatMap { locationAsset => 
+    val remoteClients = findLocations.flatMap { locationAsset =>
       val locationAttribute = MultiCollinsConfig.locationAttribute
       locationAsset.getMetaAttribute(locationAttribute).map(_.getValue) match {
         case None =>
@@ -273,7 +291,7 @@ object Asset extends Schema with AnormAdapter[Asset] {
       logger.warn("Invalid sort " + page.sort)
       SortDesc
     })
-    asset.nodeClass.map{ nodeclass => 
+    asset.nodeClass.map{ nodeclass =>
       logger.debug("Asset %s has NodeClass %s".format(asset.tag, nodeclass.tag))
       val unsortedItems:Page[AssetView] = find(
         PageParams(0,10000, "asc", "tag"), //TODO: unbounded search
@@ -282,15 +300,15 @@ object Asset extends Schema with AnormAdapter[Asset] {
         Some("and")
       )
       val sortedItems = AssetDistanceSorter.sort(
-        asset, 
-        unsortedItems.items.collect{case a: Asset => a}.filter{_.tag != asset.tag}, 
+        asset,
+        unsortedItems.items.collect{case a: Asset => a}.filter{_.tag != asset.tag},
         sortType,
         sorter
       )
       val sortedPage: Page[AssetView] = Page(
-        page = page.page, 
-        items = sortedItems.slice(page.offset, page.offset + page.size), 
-        total = sortedItems.size, 
+        page = page.page,
+        items = sortedItems.slice(page.offset, page.offset + page.size),
+        total = sortedItems.size,
         offset = page.offset
       )
       sortedPage
@@ -304,7 +322,7 @@ object Asset extends Schema with AnormAdapter[Asset] {
    * Used only when repopulating the solr index, this should not be used anywhere else
    */
   def findRaw() = inTransaction { log {
-    from(tableDef){asset => 
+    from(tableDef){asset =>
       where(AssetFinder.empty.asLogicalBoolean(asset))
       select(asset)
     }.toList

--- a/app/collins/models/AssetFinder.scala
+++ b/app/collins/models/AssetFinder.scala
@@ -32,13 +32,13 @@ case class AssetFinder(
 {
   def asLogicalBoolean(a: Asset): LogicalBoolean = {
     val tagBool = tag.map((a.tag === _))
-    val statusBool = status.map((a.status === _.id))
-    val typeBool = assetType.map((a.asset_type === _.id))
+    val statusBool = status.map((a.statusId === _.id))
+    val typeBool = assetType.map((a.assetTypeId === _.id))
     val createdAfterTs = createdAfter.map((a.created gte _.asTimestamp))
     val createdBeforeTs = createdBefore.map((a.created lte _.asTimestamp))
     val updatedAfterTs = Some((a.updated gte updatedAfter.map(_.asTimestamp).?))
     val updatedBeforeTs = Some((a.updated lte updatedBefore.map(_.asTimestamp).?))
-    val stateBool = state.map((a.state === _.id))
+    val stateBool = state.map((a.stateId === _.id))
     val ops = Seq(tagBool, statusBool, typeBool, createdAfterTs, createdBeforeTs, updatedAfterTs,
       updatedBeforeTs, stateBool).filter(_ != None).map(_.get)
     ops.reduceRight((a,b) => new BinaryOperatorNodeLogicalBoolean(a, b, "and"))

--- a/app/collins/models/AssetLifecycle.scala
+++ b/app/collins/models/AssetLifecycle.scala
@@ -196,9 +196,9 @@ class AssetLifecycle(user: Option[User], tattler: Tattler) {
         val created = AssetMetaValue.create(values)
         require(created == values.length,
           "Should have created %d rows, created %d".format(values.length, created))
-        val newAsset = asset.copy(status = Status.Unallocated.map(_.id).getOrElse(0), updated = Some(new Date().asTimestamp))
+        val newAsset = asset.copy(statusId = Status.Unallocated.map(_.id).getOrElse(0), updated = Some(new Date().asTimestamp))
         MetaWrapper.createMeta(newAsset, filtered)
-        Asset.partialUpdate(newAsset, newAsset.updated, Some(newAsset.status), State.Starting)
+        Asset.partialUpdate(newAsset, newAsset.updated, Some(newAsset.statusId), State.Starting)
         newAsset
       }
       tattler.informational("Intake now complete, asset Unallocated", unallocatedAsset)
@@ -234,8 +234,8 @@ class AssetLifecycle(user: Option[User], tattler: Tattler) {
           throw lldpParsingResults.left.get
         }
         MetaWrapper.createMeta(asset, filtered ++ Map(AssetMeta.Enum.ChassisTag.toString -> chassis_tag))
-        val newAsset = asset.copy(status = Status.New.map(_.id).getOrElse(0), updated = Some(new Date().asTimestamp))
-        Asset.partialUpdate(newAsset, newAsset.updated, Some(newAsset.status), State.New)
+        val newAsset = asset.copy(statusId = Status.New.map(_.id).getOrElse(0), updated = Some(new Date().asTimestamp))
+        Asset.partialUpdate(newAsset, newAsset.updated, Some(newAsset.statusId), State.New)
         tattler.informational("Parsing and storing LSHW/LLDP data succeeded", newAsset)
         true
       }

--- a/app/collins/models/AssetLifecycle.scala
+++ b/app/collins/models/AssetLifecycle.scala
@@ -151,7 +151,7 @@ class AssetLifecycle(user: Option[User], tattler: Tattler) {
 
   protected def updateServerHardwareMeta(asset: Asset, options: Map[String,String]): AssetLifecycle.Status[Boolean] = {
     // if asset's status is in the allowed statuses for updating, do it
-    if (Feature.allowedServerUpdateStatuses.contains(asset.getStatus())) {
+    if (Feature.allowedServerUpdateStatuses.contains(asset.status)) {
       // we will allow updates to lshw/lldp while the machine is in these statuses
       allCatch[Boolean].either {
         Asset.inTransaction {

--- a/app/collins/models/AssetLifecycle.scala
+++ b/app/collins/models/AssetLifecycle.scala
@@ -47,7 +47,7 @@ object AssetLifecycleConfig {
 
 object AssetLifecycle {
   type AssetIpmi = Tuple2[Asset,Option[IpmiInfo]]
-  type Status[T] = Either[Throwable,T]  
+  type Status[T] = Either[Throwable,T]
 }
 // Supports meta operations on assets
 class AssetLifecycle(user: Option[User], tattler: Tattler) {
@@ -65,8 +65,9 @@ class AssetLifecycle(user: Option[User], tattler: Tattler) {
           case false => None
         }
         Solr.updateAsset(asset)
-        Tuple2(asset, ipmi)
+        (asset, ipmi)
       }
+      Asset.flushCache(res._1)
       tattler.informational(
         "Initial intake successful, status now %s".format(_status.toString), res._1)
       Right(res)
@@ -281,7 +282,7 @@ class AssetLifecycle(user: Option[User], tattler: Tattler) {
     try {
       AssetLog.error(
         asset,
-        user.map{ _.username }.getOrElse(""), 
+        user.map{ _.username }.getOrElse(""),
         msg,
         LogFormat.PlainText,
         LogSource.Internal

--- a/app/collins/models/AssetLog.scala
+++ b/app/collins/models/AssetLog.scala
@@ -3,21 +3,15 @@ package collins.models
 import java.sql.Timestamp
 import java.util.Date
 
-import org.squeryl.PrimitiveTypeMode.__thisDsl
-import org.squeryl.PrimitiveTypeMode.count
-import org.squeryl.PrimitiveTypeMode.enum2EnumNode
-import org.squeryl.PrimitiveTypeMode.from
-import org.squeryl.PrimitiveTypeMode.long2ScalarLong
-import org.squeryl.PrimitiveTypeMode.optionLong2ScalarLong
-import org.squeryl.PrimitiveTypeMode.orderByArg2OrderByExpression
-import org.squeryl.PrimitiveTypeMode.singleColComputeQuery2Scalar
-import org.squeryl.PrimitiveTypeMode.traversableOfEnumerationValue2ListEnumerationValue
-import org.squeryl.PrimitiveTypeMode.where
+import org.squeryl.Schema
+import org.squeryl.annotations.Column
 
+import org.squeryl.PrimitiveTypeMode._
 import org.squeryl.Schema
 import org.squeryl.annotations.Column
 import org.squeryl.annotations.Transient
 import org.squeryl.dsl.ast.LogicalBoolean
+
 
 import play.api.libs.json.JsObject
 import play.api.libs.json.JsString
@@ -227,6 +221,13 @@ object AssetLog extends Schema with AnormAdapter[AssetLog] {
       where(a.id === id)
       select(a)
     ).toList.headOption
+  }
+  
+  def findByIds(id: Seq[Long]): List[AssetLog] = inTransaction {
+    from(tableDef)(s =>
+      where(s.id in id)
+      select(s)
+    ).toList
   }
 
   private def whereClause(a: AssetLog, asset_id: Option[Long], filter: String) = {

--- a/app/collins/models/AssetLog.scala
+++ b/app/collins/models/AssetLog.scala
@@ -5,13 +5,11 @@ import java.util.Date
 
 import org.squeryl.Schema
 import org.squeryl.annotations.Column
-
 import org.squeryl.PrimitiveTypeMode._
 import org.squeryl.Schema
 import org.squeryl.annotations.Column
 import org.squeryl.annotations.Transient
 import org.squeryl.dsl.ast.LogicalBoolean
-
 
 import play.api.libs.json.JsObject
 import play.api.libs.json.JsString
@@ -22,7 +20,6 @@ import collins.models.conversions.orderByString2oba
 import collins.models.shared.AnormAdapter
 import collins.models.shared.Page
 import collins.models.shared.ValidatedEntity
-
 import collins.models.conversions.AssetLogFormat
 import collins.models.logs.LogFormat
 import collins.models.logs.LogFormat.LogFormat
@@ -79,7 +76,7 @@ case class AssetLog(
     messageType == LogMessageType.Informational
   def isDebug(): Boolean =
     messageType == LogMessageType.Debug
-  
+
   @Transient
   lazy val assetTag: String = asset.tag
   @Transient
@@ -121,7 +118,7 @@ case class AssetLog(
   }
 }
 
-object AssetLog extends Schema with AnormAdapter[AssetLog] {
+object AssetLog extends Schema with AnormAdapter[AssetLog] with AssetLogKeys {
 
   override val createEventName = Some("asset_log_create")
 
@@ -217,12 +214,12 @@ object AssetLog extends Schema with AnormAdapter[AssetLog] {
   }
 
   def findById(id: Long): Option[AssetLog] = inTransaction {
-    from(tableDef)(a => 
+    from(tableDef)(a =>
       where(a.id === id)
       select(a)
     ).toList.headOption
   }
-  
+
   def findByIds(id: Seq[Long]): List[AssetLog] = inTransaction {
     from(tableDef)(s =>
       where(s.id in id)
@@ -241,7 +238,7 @@ object AssetLog extends Schema with AnormAdapter[AssetLog] {
   }
 
   private def filterToClause(filter: String, log: AssetLog): LogicalBoolean = {
-    val (negated, filters) = filter.split(';').foldLeft(false,Set[LogMessageType]()) { case(tuple, fs) => 
+    val (negated, filters) = filter.split(';').foldLeft(false,Set[LogMessageType]()) { case(tuple, fs) =>
       val negate = fs.startsWith("!")
       val mt = negate match {
         case true =>

--- a/app/collins/models/AssetMeta.scala
+++ b/app/collins/models/AssetMeta.scala
@@ -43,7 +43,6 @@ case class AssetMeta(
       "DESCRIPTION" -> JsString(description)
     )))
   }
-  def getId(): Long = id
 
   def getValueType(): AssetMeta.ValueType = AssetMeta.ValueType(value_type)
 

--- a/app/collins/models/AssetMeta.scala
+++ b/app/collins/models/AssetMeta.scala
@@ -16,6 +16,7 @@ import collins.solr.SolrDoubleValue
 import collins.solr.SolrBooleanValue
 import collins.solr.SolrStringValue
 
+import collins.models.cache.Cache
 import collins.models.shared.ValidatedEntity
 import collins.models.shared.AnormAdapter
 
@@ -72,7 +73,7 @@ case class AssetMeta(
   }
 }
 
-object AssetMeta extends Schema with AnormAdapter[AssetMeta] {
+object AssetMeta extends Schema with AnormAdapter[AssetMeta] with AssetMetaKeys {
   private[this] val NameR = """[A-Za-z0-9\-_]+""".r.pattern.matcher(_)
 
   override val tableDef = table[AssetMeta]("asset_meta")
@@ -92,39 +93,40 @@ object AssetMeta extends Schema with AnormAdapter[AssetMeta] {
     name != null && name.nonEmpty && NameR(name).matches
   }
 
-  def findAll(): Seq[AssetMeta] = inTransaction {
+  def findAll(): List[AssetMeta] = Cache.get(findByAllKey, inTransaction {
     from(tableDef)(s => select(s)).toList
-  }
+  })
 
-  def findById(id: Long) = inTransaction {
+  def findById(id: Long) = Cache.get(findByIdKey(id), inTransaction {
     tableDef.lookup(id)
-  }
+  })
 
   def findOrCreateFromName(name: String, valueType: ValueType = ValueType.String): AssetMeta = findByName(name).getOrElse {
     create(AssetMeta(
-      name = name.toUpperCase, 
-      priority = -1, 
-      label = name.toLowerCase.capitalize, 
+      name = name.toUpperCase,
+      priority = -1,
+      label = name.toLowerCase.capitalize,
       description = name,
       value_type = valueType.id
     ))
+    findByName(name).get
   }
 
   override def get(a: AssetMeta) = findById(a.id).get
 
-  def findByName(name: String): Option[AssetMeta] = inTransaction {
+  def findByName(name: String): Option[AssetMeta] = Cache.get(findByNameKey(name), inTransaction {
     tableDef.where(a =>
       a.name.toUpperCase === name.toUpperCase
     ).headOption
-  }
+  })
 
-  def getViewable(): Seq[AssetMeta] = inTransaction {
+  def getViewable(): List[AssetMeta] = Cache.get(findByViewableKey,  inTransaction {
     from(tableDef)(a =>
       where(a.priority gt -1)
       select(a)
       orderBy(a.priority asc)
     ).toList
-  }
+  })
 
   type ValueType = ValueType.Value
   object ValueType extends Enumeration {

--- a/app/collins/models/AssetMetaValue.scala
+++ b/app/collins/models/AssetMetaValue.scala
@@ -4,6 +4,8 @@ import org.squeryl.PrimitiveTypeMode._
 import org.squeryl.Schema
 import org.squeryl.dsl.ast.BinaryOperatorNodeLogicalBoolean
 import org.squeryl.dsl.ast.LogicalBoolean
+import org.squeryl.annotations.Transient
+import org.squeryl.annotations.Column
 
 import play.api.Logger
 
@@ -19,13 +21,14 @@ import collins.models.asset.AssetView
 import collins.models.conversions.ops2bo
 import collins.models.conversions.reOrLike
 
-case class AssetMetaValue(asset_id: Long, asset_meta_id: Long, group_id: Int, value: String) {
+case class AssetMetaValue(@Column("ASSET_ID") assetId: Long, @Column("ASSET_META_ID") assetMetaId: Long,@Column("GROUP_ID") groupId: Int, value: String) {
 
-  def getAsset(): Asset = Asset.findById(asset_id).get
-  def getAssetId(): Long = asset_id
-  def getMeta(): AssetMeta = AssetMeta.findById(asset_meta_id).get
+  @Transient
+  lazy val asset: Asset = Asset.findById(assetId).get
+  @Transient
+  lazy val meta: AssetMeta = AssetMeta.findById(assetMetaId).get
 
-  require(asset_meta_id == 0 || getMeta().validateValue(value), "Invalid format for value" + value)
+  require(assetMetaId == 0 || meta.validateValue(value), "Invalid format for value" + value)
 
 }
 
@@ -35,24 +38,24 @@ object AssetMetaValue extends Schema with BasicModel[AssetMetaValue] {
 
   val tableDef = table[AssetMetaValue]("asset_meta_value")
   on(tableDef)(a => declare(
-    a.asset_meta_id is(indexed),
-    a.group_id is(indexed),
-    a.group_id defaultsTo(0),
-    columns(a.asset_id, a.asset_meta_id) are(indexed)
+    a.assetMetaId is(indexed),
+    a.groupId is(indexed),
+    a.groupId defaultsTo(0),
+    columns(a.assetId, a.assetMetaId) are(indexed)
   ))
 
-  def apply(asset: Asset, asset_meta_id: Long, value: String) =
-    new AssetMetaValue(asset.getId, asset_meta_id, 0, value)
+  def apply(asset: Asset, assetMetaId: Long, value: String) =
+    new AssetMetaValue(asset.id, assetMetaId, 0, value)
   def apply(asset: Asset, asset_meta: AssetMeta.Enum, value: String) =
-    new AssetMetaValue(asset.getId, asset_meta.id, 0, value)
-  def apply(asset: Asset, asset_meta_id: Long, group_id: Int, value: String) =
-    new AssetMetaValue(asset.getId, asset_meta_id, group_id, value)
-  def apply(asset: Asset, asset_meta: AssetMeta.Enum, group_id: Int, value: String) =
-    new AssetMetaValue(asset.getId, asset_meta.id, group_id, value)
+    new AssetMetaValue(asset.id, asset_meta.id, 0, value)
+  def apply(asset: Asset, assetMetaId: Long, groupId: Int, value: String) =
+    new AssetMetaValue(asset.id, assetMetaId, groupId, value)
+  def apply(asset: Asset, asset_meta: AssetMeta.Enum, groupId: Int, value: String) =
+    new AssetMetaValue(asset.id, asset_meta.id, groupId, value)
   def apply(asset: Asset, assetMeta: AssetMeta, value: String) =
-    new AssetMetaValue(asset.getId, assetMeta.getId, 0, value)
+    new AssetMetaValue(asset.id, assetMeta.id, 0, value)
   def apply(asset: Asset, assetMeta: AssetMeta, groupId: Int, value: String) =
-    new AssetMetaValue(asset.getId, assetMeta.getId, groupId, value)
+    new AssetMetaValue(asset.id, assetMeta.id, groupId, value)
 
   override def callbacks = super.callbacks ++ Seq(
     beforeInsert(tableDef).map(v =>
@@ -67,7 +70,7 @@ object AssetMetaValue extends Schema with BasicModel[AssetMetaValue] {
 
   def shouldEncrypt(v: AssetMetaValue): Boolean = {
     try {
-      Feature.encryptedTags.map(_.name).contains(v.getMeta().name)
+      Feature.encryptedTags.map(_.name).contains(v.meta.name)
     } catch {
       case e: Throwable =>
         logger.error("Caught exception trying to determine whether to encrypt", v)
@@ -92,8 +95,8 @@ object AssetMetaValue extends Schema with BasicModel[AssetMetaValue] {
   override def delete(a: AssetMetaValue): Int = inTransaction {
     afterDeleteCallback(a) {
       tableDef.deleteWhere(p =>
-        p.asset_id === a.asset_id and
-        p.asset_meta_id === a.asset_meta_id
+        p.assetId === a.assetId and
+        p.assetMetaId === a.assetMetaId
       )
     }
   }
@@ -101,7 +104,7 @@ object AssetMetaValue extends Schema with BasicModel[AssetMetaValue] {
   def deleteByAsset(asset: Asset): Int = inTransaction {
     val meta = AssetMetaValue(asset, 0, "")
     afterDeleteCallback(meta) {
-      tableDef.deleteWhere(p => p.asset_id === asset.getId)
+      tableDef.deleteWhere(p => p.assetId === asset.id)
     }
   }
 
@@ -112,9 +115,9 @@ object AssetMetaValue extends Schema with BasicModel[AssetMetaValue] {
   def find(mv: AssetMetaValue, useValue: Boolean, groupId: Option[Int]): Option[AssetMetaValue] = inTransaction { log {
     from(tableDef)(a =>
       where {
-        a.asset_id === mv.asset_id and
-        a.asset_meta_id === mv.asset_meta_id and
-        a.group_id === groupId.? and
+        a.assetId === mv.assetId and
+        a.assetMetaId === mv.assetMetaId and
+        a.groupId === groupId.? and
         a.value === mv.value.inhibitWhen(useValue == false)
       }
       select(a)
@@ -145,30 +148,30 @@ object AssetMetaValue extends Schema with BasicModel[AssetMetaValue] {
 
   def findByAsset(asset: Asset, checkCache: Boolean = true): Seq[MetaWrapper] = inTransaction {
       from(tableDef)(a =>
-        where(a.asset_id === asset.id)
+        where(a.assetId === asset.id)
         select(a)
       ).toList.map { amv =>
-        MetaWrapper(amv.getMeta(), amv)
+        MetaWrapper(amv.meta, amv)
       }
   }
 
   def findByAssetAndMeta(asset: Asset, meta: AssetMeta, count: Int): Seq[MetaWrapper] = inTransaction {
     from(tableDef)(a =>
-      where(a.asset_id === asset.getId and a.asset_meta_id === meta.id)
+      where(a.assetId === asset.id and a.assetMetaId === meta.id)
       select(a)
     ).page(0, count).toList.map(mv => MetaWrapper(meta, mv))
   }
 
   def findByMeta(meta: AssetMeta): Seq[String] = inTransaction {
     from(tableDef)(a =>
-      where(a.asset_meta_id === meta.id)
+      where(a.assetMetaId === meta.id)
       select(a.value)
     ).distinct.toList.sorted
   }
 
   def purge(mvs: Seq[AssetMetaValue], groupId: Option[Int]) = {
     mvs.map(mv => (find(mv, false, groupId), mv)).foreach { case(oldValue, newValue) =>
-      val deleteCount = deleteByAssetIdAndMetaId(newValue.asset_id, Set(newValue.asset_meta_id), groupId)
+      val deleteCount = deleteByAssetIdAndMetaId(newValue.assetId, Set(newValue.assetMetaId), groupId)
       if (deleteCount > 0 && shouldLogChange(oldValue, newValue)) {
         logChange(oldValue, newValue)
       } else {
@@ -177,15 +180,15 @@ object AssetMetaValue extends Schema with BasicModel[AssetMetaValue] {
     }
   }
 
-  protected def deleteByAssetIdAndMetaId(asset_id: Long, meta_id: Set[Long], groupId: Option[Int]): Int = {
+  protected def deleteByAssetIdAndMetaId(assetId: Long, meta_id: Set[Long], groupId: Option[Int]): Int = {
     inTransaction {
       val results = tableDef.deleteWhere { p =>
-        (p.asset_id === asset_id) and
-        (p.group_id === groupId.?) and
-        (p.asset_meta_id in meta_id)
+        (p.assetId === assetId) and
+        (p.groupId === groupId.?) and
+        (p.assetMetaId in meta_id)
       }
       meta_id.foreach { id =>
-        val meta = new AssetMetaValue(asset_id, id, 0, "")
+        val meta = new AssetMetaValue(assetId, id, 0, "")
         afterDeleteCallback(meta) {
           // no op
         }
@@ -205,7 +208,7 @@ object AssetMetaValue extends Schema with BasicModel[AssetMetaValue] {
     // Don't need value for excludes match, just want assets that have a value
     val subqueries = clauses.map { case(am, v) =>
       from(tableDef)(a =>
-        where(a.asset_id === asset.id and a.asset_meta_id === am.id)
+        where(a.assetId === asset.id and a.assetMetaId === am.id)
         select(&(1))
       )
     }
@@ -234,24 +237,24 @@ object AssetMetaValue extends Schema with BasicModel[AssetMetaValue] {
     oldValue match {
       case None =>
       case Some(oValue) =>
-        val metaName = newValue.getMeta().name
+        val metaName = newValue.meta.name
         val newValueS = if (Feature.encryptedTags.map(_.name).contains(metaName)) {
           val msg = "Value of '%s' was changed".format(metaName)
-          InternalTattler.notice(msg, newValue.getAsset)
+          InternalTattler.notice(msg, newValue.asset)
         } else {
           val msg = "Deleting old %s value '%s', setting to '%s'".format(
-                    AssetMeta.findById(newValue.asset_meta_id).map(_.name).getOrElse("Unknown"),
+                    AssetMeta.findById(newValue.assetMetaId).map(_.name).getOrElse("Unknown"),
                     oValue.value, newValue.value)
-          InternalTattler.notice(msg, newValue.getAsset)
+          InternalTattler.notice(msg, newValue.asset)
         }
     }
   }
 
   protected def shouldLogChange(oldValue: Option[AssetMetaValue], newValue: AssetMetaValue): Boolean = {
-    val newAsset = Asset.findById(newValue.asset_id)
+    val newAsset = Asset.findById(newValue.assetId)
     val excludeAsset = newAsset.isDefined && Feature.noLogAssets.map(_.toLowerCase).contains(newAsset.get.tag.toLowerCase)
     oldValue.isDefined &&
-    !Feature.noLogPurges.map(AssetMeta.findByName(_).map(_.id).getOrElse(0L)).contains(newValue.asset_meta_id) &&
+    !Feature.noLogPurges.map(AssetMeta.findByName(_).map(_.id).getOrElse(0L)).contains(newValue.assetMetaId) &&
     !excludeAsset &&
     oldValue.get.value != newValue.value
   }
@@ -259,7 +262,7 @@ object AssetMetaValue extends Schema with BasicModel[AssetMetaValue] {
   private def matchClause(asset: Asset, am: AssetMeta, v: String) = {
     from(tableDef)(a =>
       where(
-        a.asset_id === asset.id and a.asset_meta_id === am.id and a.value.withPossibleRegex(v)
+        a.assetId === asset.id and a.assetMetaId === am.id and a.value.withPossibleRegex(v)
       )
       select(&(1))
     )

--- a/app/collins/models/AssetType.scala
+++ b/app/collins/models/AssetType.scala
@@ -9,6 +9,7 @@ import play.api.libs.json.JsSuccess
 import play.api.libs.json.JsValue
 import play.api.libs.json.Json
 
+import collins.models.cache.Cache
 import collins.models.shared.AnormAdapter
 import collins.models.shared.ValidatedEntity
 
@@ -22,7 +23,7 @@ case class AssetType(name: String, label: String, id: Int = 0) extends Validated
   override def toString(): String = name
 }
 
-object AssetType extends Schema with AnormAdapter[AssetType] {
+object AssetType extends Schema with AnormAdapter[AssetType] with AssetTypeKeys {
 
   override val tableDef = table[AssetType]("asset_type")
   val reservedNames = List("SERVER_NODE","SERVER_CHASSIS","RACK","SWITCH","ROUTER","POWER_CIRCUIT","POWER_STRIP","DATA_CENTER","CONFIGURATION")
@@ -44,21 +45,21 @@ object AssetType extends Schema with AnormAdapter[AssetType] {
     ))
   }
 
-  def findById(id: Int): Option[AssetType] = inTransaction {
+  def findById(id: Int): Option[AssetType] = Cache.get(findByIdKey(id), inTransaction {
     tableDef.lookup(id)
-  }
+  })
 
   override def get(a: AssetType) = findById(a.id).get
 
-  def find(): List[AssetType] = inTransaction {
+  def find(): List[AssetType] = Cache.get(findKey, inTransaction {
     from(tableDef)(at => select(at)).toList
-  }
+  })
 
-  def findByName(name: String): Option[AssetType] = inTransaction {
+  def findByName(name: String): Option[AssetType] = Cache.get(findByNameKey(name), inTransaction {
     tableDef.where(a =>
       a.name.toLowerCase === name.toLowerCase
     ).headOption
-  }
+  })
 
   override def delete(a: AssetType): Int = inTransaction {
     afterDeleteCallback(a) {

--- a/app/collins/models/AssetType.scala
+++ b/app/collins/models/AssetType.scala
@@ -13,7 +13,6 @@ import collins.models.shared.AnormAdapter
 import collins.models.shared.ValidatedEntity
 
 case class AssetType(name: String, label: String, id: Int = 0) extends ValidatedEntity[Int] {
-  def getId(): Int = id
   override def validate() {
     require(name != null && name.length > 0, "Name must not be empty")
   }

--- a/app/collins/models/IpAddresses.scala
+++ b/app/collins/models/IpAddresses.scala
@@ -71,7 +71,7 @@ object IpAddresses extends IpAddressStorage[IpAddresses] {
   }
 
   def createForAsset(asset: Asset, scope: Option[String]): IpAddresses = inTransaction {
-    val assetId = asset.getId
+    val assetId = asset.id
     val cfg = getConfig()(scope)
     val ipAddresses = createWithRetry(10) { attempt =>
       val (gateway, address, netmask) = getNextAddress(attempt)(scope)

--- a/app/collins/models/IpmiInfo.scala
+++ b/app/collins/models/IpmiInfo.scala
@@ -61,7 +61,7 @@ object IpmiInfo extends IpAddressStorage[IpmiInfo] {
   ))
 
   def createForAsset(asset: Asset): IpmiInfo = inTransaction {
-    val assetId = asset.getId
+    val assetId = asset.id
     val username = getUsername(asset)
     val password = generateEncryptedPassword()
     createWithRetry(10) { attempt =>

--- a/app/collins/models/Keys.scala
+++ b/app/collins/models/Keys.scala
@@ -1,0 +1,104 @@
+package collins.models
+
+import org.squeryl.Schema
+
+import collins.models.shared.Keys
+import collins.models.shared.BasicModel
+import collins.models.shared.AnormAdapter
+import collins.models.shared.IpAddressable
+import collins.models.shared.IpAddressStorage
+
+trait StateKeys extends Keys[State] { self: AnormAdapter[State] =>
+
+  val findKey = "State.find"
+  def findByIdKey(id: Int) = f"State.findById(${id}%d)"
+  def findByNameKey(name: String) = f"State.findByName(${name.toLowerCase}%s)"
+  val findByAnyStatusKey = "State.findByAnyStatus"
+  def findByStatusKey(status: Int) = f"State.findByStatus(${status}%d)"
+
+  override def cacheKeys(s: State) = Seq(
+    findKey,
+    findByIdKey(s.id),
+    findByNameKey(s.name),
+    findByAnyStatusKey,
+    findByStatusKey(s.status))
+}
+
+trait AssetLogKeys extends Keys[AssetLog] { self: AnormAdapter[AssetLog] =>
+  def cacheKeys(l: AssetLog) = Seq()
+}
+
+trait AssetMetaValueKeys extends Keys[AssetMetaValue] { self: BasicModel[AssetMetaValue] =>
+
+  def findByMetaKey(id: Long) = f"AssetMetaValue.findByMeta(${id}%d)"
+  def findByAssetKey(id: Long) = f"AssetMetaValue.findByAsset(${id}%d)"
+  def findByAssetAndMetaKey(assetId: Long, metaId: Long) = f"AssetMetaValue.findByAssetAndMeta(${assetId}%d, ${metaId}%d)"
+
+  def cacheKeys(amv: AssetMetaValue) = Seq(
+    findByMetaKey(amv.assetMetaId),
+    findByAssetKey(amv.assetId),
+    findByAssetAndMetaKey(amv.assetId, amv.assetMetaId))
+}
+
+trait IpAddressKeys[T <: IpAddressable] extends Keys[T] { self: IpAddressStorage[T] =>
+
+  def findAllByAssetKey(id: Long) = f"${storageName}%s.findAllByAsset(${id}%d)"
+  def findByAssetKey(id: Long) = f"${storageName}%s.findByAsset(${id}%d)"
+  def findByIdKey(id: Long) = f"${storageName}%s.get(${id}%d)"
+  val findPoolsInUseKey = "getPoolsInUse"
+
+  override def cacheKeys(t: T) = {
+    Seq(
+      findAllByAssetKey(t.assetId),
+      findByAssetKey(t.assetId),
+      findByIdKey(t.id),
+      findPoolsInUseKey)
+  }
+}
+
+trait StatusKeys extends Keys[Status] { self: AnormAdapter[Status] =>
+  val findKey = "Status.find"
+  def findByIdKey(id: Int) = f"Status.findById(${id}%d)"
+  def findByNameKey(name: String) = f"Status.findByName(${name.toLowerCase}%s)"
+
+  override def cacheKeys(s: Status) = Seq(
+    findKey,
+    findByIdKey(s.id),
+    findByNameKey(s.name))
+}
+
+trait AssetKeys extends Keys[Asset] { self: AnormAdapter[Asset] =>
+
+  def findByTagKey(tag: String) = f"Asset.findByTag(${tag.toLowerCase}%s)"
+  def findByIdKey(id: Long) = f"Asset.findById(${id}%d)"
+
+  override def cacheKeys(asset: Asset) = Seq(
+    findByTagKey(asset.tag),
+    findByIdKey(asset.id))
+}
+
+trait AssetMetaKeys extends Keys[AssetMeta] { self: AnormAdapter[AssetMeta] =>
+
+  val findByAllKey = "AssetMeta.findAll"
+  val findByViewableKey = "AssetMeta.getViewable"
+  def findByIdKey(id: Long) = f"AssetMeta.findById(${id}%d)"
+  def findByNameKey(name: String) = f"AssetMeta.findByName(${name.toUpperCase}%s)"
+
+  override def cacheKeys(a: AssetMeta) = Seq(
+    findByNameKey(a.name),
+    findByIdKey(a.id),
+    findByAllKey,
+    findByViewableKey)
+}
+
+trait AssetTypeKeys extends Keys[AssetType] { self: AnormAdapter[AssetType] =>
+
+  val findKey = "AssetType.find"
+  def findByNameKey(name: String) = f"AssetType.findByName(${name.toUpperCase}%s)"
+  def findByIdKey(id: Int) = f"AssetType.findById(${id}%d)"
+
+  override def cacheKeys(a: AssetType) = Seq(
+    findByIdKey(a.id),
+    findByNameKey(a.name),
+    findKey)
+}

--- a/app/collins/models/LldpHelper.scala
+++ b/app/collins/models/LldpHelper.scala
@@ -31,7 +31,7 @@ object LldpHelper extends CommonHelper[LldpRepresentation] {
     if (lldp.interfaceCount < 1) {
       return Seq()
     }
-    val asset_id = asset.getId
+    val asset_id = asset.id
     lldp.interfaces.zipWithIndex.foldLeft(Seq[AssetMetaValue]()) { case(seq,tuple) =>
       val interface = tuple._1
       val groupId = tuple._2

--- a/app/collins/models/MetaWrapper.scala
+++ b/app/collins/models/MetaWrapper.scala
@@ -6,11 +6,11 @@ import collins.util.CryptoCodec
  * Provide a convenience wrapper on top of a row of meta/value data
  */
 case class MetaWrapper(_meta: AssetMeta, _value: AssetMetaValue) {
-  def getAssetId(): Long = _value.asset_id
+  def getAssetId(): Long = _value.assetId
   def getMetaId(): Long = _meta.id
   def getId(): (Long,Long) = (getAssetId(), getMetaId())
   def getName(): String = _meta.name
-  def getGroupId(): Int = _value.group_id
+  def getGroupId(): Int = _value.groupId
   def getPriority(): Int = _meta.priority
   def getLabel(): String = _meta.label
   def getDescription(): String = _meta.description
@@ -24,7 +24,7 @@ case class MetaWrapper(_meta: AssetMeta, _value: AssetMetaValue) {
 }
 
 object MetaWrapper {
-  def apply(amv: AssetMetaValue): MetaWrapper = MetaWrapper(amv.getMeta, amv)
+  def apply(amv: AssetMetaValue): MetaWrapper = MetaWrapper(amv.meta, amv)
   def createMeta(asset: Asset, metas: Map[String,String], groupId: Option[Int] = None) = {
     val metaValues = metas.map { case(k,v) =>
       val meta = AssetMeta.findOrCreateFromName(k)

--- a/app/collins/models/Status.scala
+++ b/app/collins/models/Status.scala
@@ -1,12 +1,7 @@
 package collins.models
 
-import scala.math.BigDecimal.int2bigDecimal
+import org.squeryl.PrimitiveTypeMode._
 
-import org.squeryl.PrimitiveTypeMode.__thisDsl
-import org.squeryl.PrimitiveTypeMode.from
-import org.squeryl.PrimitiveTypeMode.int2ScalarInt
-import org.squeryl.PrimitiveTypeMode.select
-import org.squeryl.PrimitiveTypeMode.string2ScalarString
 import org.squeryl.Schema
 
 import play.api.libs.json.Format
@@ -17,6 +12,7 @@ import play.api.libs.json.JsSuccess
 import play.api.libs.json.JsValue
 import play.api.libs.json.Json
 
+import collins.models.cache.Cache
 import collins.models.shared.AnormAdapter
 import collins.models.shared.ValidatedEntity
 
@@ -32,7 +28,7 @@ case class Status(name: String, description: String, id: Int = 0) extends Valida
   override def toString(): String = name
 }
 
-object Status extends Schema with AnormAdapter[Status] {
+object Status extends Schema with AnormAdapter[Status] with StatusKeys {
 
   def Allocated = Status.findByName("Allocated")
   def Cancelled = Status.findByName("Cancelled")
@@ -63,21 +59,21 @@ object Status extends Schema with AnormAdapter[Status] {
     s.name is(unique)
   ))
 
-  def find(): List[Status] = inTransaction {
+  def find(): List[Status] = Cache.get(findKey, inTransaction {
     from(tableDef)(s => select(s)).toList
-  }
-  
-  def findById(id: Int): Option[Status] = inTransaction {
+  })
+
+  def findById(id: Int): Option[Status] = Cache.get(findByIdKey(id), inTransaction {
     tableDef.lookup(id)
-  }
+  })
 
   override def get(s: Status) = findById(s.id).get
 
-  def findByName(name: String): Option[Status] = inTransaction {
+  def findByName(name: String): Option[Status] = Cache.get(findByNameKey(name), inTransaction {
     tableDef.where(s =>
       s.name.toLowerCase === name.toLowerCase
     ).headOption
-  }
+  })
 
   override def delete(s: Status): Int = inTransaction {
     afterDeleteCallback(s) {

--- a/app/collins/models/Status.scala
+++ b/app/collins/models/Status.scala
@@ -21,7 +21,6 @@ import collins.models.shared.AnormAdapter
 import collins.models.shared.ValidatedEntity
 
 case class Status(name: String, description: String, id: Int = 0) extends ValidatedEntity[Int] {
-  def getId(): Int = id
   override def validate() {
     require(name != null && name.length > 0, "Name must not be empty")
     require(description != null && description.length > 0, "Description must not be empty")

--- a/app/collins/models/asset/AssetDeleter.scala
+++ b/app/collins/models/asset/AssetDeleter.scala
@@ -1,13 +1,15 @@
 package collins.models.asset
 
-import org.squeryl.PrimitiveTypeMode.__thisDsl
-import org.squeryl.PrimitiveTypeMode.long2ScalarLong
+import org.squeryl.PrimitiveTypeMode._
+
+import collins.models.cache.Cache
 
 import collins.models.Asset
 import collins.models.AssetLog
 import collins.models.AssetMetaValue
 import collins.models.IpAddresses
 import collins.models.IpmiInfo
+
 import collins.callbacks.Callback
 
 object AssetDeleter {
@@ -22,6 +24,7 @@ object AssetDeleter {
     }
     if (result) {
       Callback.fire("asset_purge", tag, null)
+      Cache.clear()
     }
     result
   }

--- a/app/collins/models/asset/AssetDeleter.scala
+++ b/app/collins/models/asset/AssetDeleter.scala
@@ -30,7 +30,7 @@ object AssetDeleter {
     AssetMetaValue.deleteByAsset(asset) >= 0
   }
   protected def deleteLogs(asset: Asset): Boolean = {
-    AssetLog.tableDef.deleteWhere(al => al.asset_id === asset.id) >= 0
+    AssetLog.tableDef.deleteWhere(al => al.assetId === asset.id) >= 0
   }
   protected def deleteIpmiInfo(asset: Asset): Boolean = {
     IpmiInfo.deleteByAsset(asset) >= 0

--- a/app/collins/models/asset/AssetView.scala
+++ b/app/collins/models/asset/AssetView.scala
@@ -18,9 +18,9 @@ trait AssetView {
 
   def id: Long
   def tag: String
-  def status: Int
-  def state: Int
-  def asset_type: Int
+  def statusId: Int
+  def stateId: Int
+  def assetTypeId: Int
   def created: Timestamp
   def updated: Option[Timestamp]
   def deleted: Option[Timestamp]
@@ -31,9 +31,9 @@ trait AssetView {
   def remoteHost: Option[String] //none if local
   def toJsValue(): JsValue
 
-  def getStatusName(): String = Status.findById(status).map(_.name).getOrElse("Unknown")
-  def getStateName(): String = State.findById(state).map(_.name).getOrElse("Unknown")
-  def getTypeName(): String = AssetType.findById(asset_type).map(_.name).getOrElse("Unknown")
+  def getStatusName(): String
+  def getStateName(): String
+  def getTypeName(): String
 
   def isServerNode(): Boolean = isAssetType(AssetType.ServerNode)
   def isConfiguration(): Boolean = isAssetType(AssetType.Configuration)
@@ -50,9 +50,9 @@ trait AssetView {
   def isMaintenance(): Boolean = isStatus(Status.Maintenance)
 
   private def isStatus(statusOpt: Option[Status]): Boolean = {
-    statusOpt.map(_.id).filter(_.equals(status)).isDefined
+    statusOpt.map(_.id).filter(_.equals(statusId)).isDefined
   }
   protected def isAssetType(atOpt: Option[AssetType]): Boolean = {
-    atOpt.map(_.id).filter(_.equals(asset_type)).isDefined
+    atOpt.map(_.id).filter(_.equals(assetTypeId)).isDefined
   }
 }

--- a/app/collins/models/asset/RemoteAssetProxy.scala
+++ b/app/collins/models/asset/RemoteAssetProxy.scala
@@ -14,12 +14,15 @@ abstract class RemoteAssetProxy(jsonAsset: JsValue) extends RemoteAsset {
 
   def id = asset.id
   def tag = asset.tag
-  def state = asset.state
-  def status = asset.status
-  def asset_type = asset.asset_type
+  def stateId = asset.stateId
+  def statusId = asset.statusId
+  def assetTypeId = asset.assetTypeId
   def created = asset.created
   def updated = asset.updated
   def deleted = asset.deleted
+  def getStatusName() = asset.getStatusName()
+  def getStateName() = asset.getStateName()
+  def getTypeName() = asset.getTypeName()
 
   def toJsValue() = {
     AssetFormat.writes(asset) ++ JsObject(Seq("LOCATION" -> JsString(hostTag)))

--- a/app/collins/models/asset/conversions.scala
+++ b/app/collins/models/asset/conversions.scala
@@ -33,9 +33,9 @@ object conversions {
     override def writes(asset: AssetView): JsObject = JsObject(Seq(
       "ID" -> JsNumber(asset.id),
       "TAG" -> JsString(asset.tag),
-      "STATE" -> Json.toJson(State.findById(asset.state)),
+      "STATE" -> Json.toJson(State.findById(asset.stateId)),
       "STATUS" -> JsString(asset.getStatusName),
-      "TYPE" -> Json.toJson(AssetType.findById(asset.asset_type).map(_.name)),
+      "TYPE" -> Json.toJson(AssetType.findById(asset.assetTypeId).map(_.name)),
       "CREATED" -> Json.toJson(asset.created),
       "UPDATED" -> Json.toJson(asset.updated),
       "DELETED" -> Json.toJson(asset.deleted)

--- a/app/collins/models/cache/Cache.scala
+++ b/app/collins/models/cache/Cache.scala
@@ -1,0 +1,49 @@
+package collins.models.cache
+
+import java.util.concurrent.Callable
+
+import play.api.Logger
+
+import com.google.common.cache.{ Cache => BasicCache }
+
+import collins.cache.CacheConfig
+import collins.cache.GuavaCacheFactory
+
+object Cache {
+
+  private val logger = Logger(getClass)
+  private[this] var cache: Option[BasicCache[String, AnyRef]] = None
+
+  def setupCache() {
+    logger.trace("Initializing cache")
+    if (CacheConfig.enabled) {
+      cache = Some(GuavaCacheFactory.create(CacheConfig.specification))
+    }
+  }
+
+  private[models] def invalidate(key: String) {
+    logger.trace(s"Invalidating cache key $key")
+    cache.map(_.invalidate(key))
+  }
+
+  private[models] def clear() {
+    logger.trace("Clearing cache")
+    cache.map(_.invalidateAll())
+  }
+
+  private[this] implicit def f2c[T](f: => T): Callable[T] = new Callable[T] { def call: T = f }
+  private[models] def get[T <: AnyRef](key: String, loader: => T): T = {
+    logger.trace(s"Obtaining cache $key with loader")
+    cache.map(_.get(key, loader).asInstanceOf[T]).getOrElse(loader)
+  }
+
+  private[models] def get[T <: AnyRef](key: String): Option[T] = {
+    logger.trace(s"Obtaining cache $key")
+    cache.map(_.getIfPresent(key).asInstanceOf[T]).filter { _ != null }
+  }
+
+  private[models] def put[T <: AnyRef](key: String, value: T) {
+    logger.trace(s"Setting cache $key")
+    cache.map(_.put(key, value))
+  }
+}

--- a/app/collins/models/conversions.scala
+++ b/app/collins/models/conversions.scala
@@ -96,12 +96,12 @@ object conversions {
     ))
     override def writes(log: AssetLog) = JsObject(Seq(
       "ID" -> Json.toJson(log.id),
-      "ASSET_TAG" -> Json.toJson(Asset.findById(log.asset_id).map(_.tag).getOrElse("Unknown")),
+      "ASSET_TAG" -> Json.toJson(Asset.findById(log.assetId).map(_.tag).getOrElse("Unknown")),
       "CREATED" -> Json.toJson(df.format(log.created)),
-      "CREATED_BY" -> Json.toJson(log.created_by),
+      "CREATED_BY" -> Json.toJson(log.createdBy),
       "FORMAT" -> Json.toJson(log.format.toString),
       "SOURCE" -> Json.toJson(log.source.toString),
-      "TYPE" -> Json.toJson(log.message_type.toString),
+      "TYPE" -> Json.toJson(log.messageType.toString),
       "MESSAGE" -> (if (log.isJson()) {
         try {
           Json.parse(log.message)

--- a/app/collins/models/conversions.scala
+++ b/app/collins/models/conversions.scala
@@ -83,7 +83,6 @@ object conversions {
     ))
   }
   implicit object AssetLogFormat extends Format[AssetLog] {
-    val df = new SimpleDateFormat("d/M/yy HH:mm:ss")
     override def reads(json: JsValue) = JsSuccess(AssetLog(
       (json \ "ASSET_ID").as[Long],
       (json \ "CREATED").as[Timestamp],
@@ -97,7 +96,7 @@ object conversions {
     override def writes(log: AssetLog) = JsObject(Seq(
       "ID" -> Json.toJson(log.id),
       "ASSET_TAG" -> Json.toJson(Asset.findById(log.assetId).map(_.tag).getOrElse("Unknown")),
-      "CREATED" -> Json.toJson(df.format(log.created)),
+      "CREATED" -> Json.toJson(log.created),
       "CREATED_BY" -> Json.toJson(log.createdBy),
       "FORMAT" -> Json.toJson(log.format.toString),
       "SOURCE" -> Json.toJson(log.source.toString),

--- a/app/collins/models/conversions.scala
+++ b/app/collins/models/conversions.scala
@@ -53,8 +53,8 @@ object conversions {
       (json \ "ID").asOpt[Long].getOrElse(0L)
     ))
     override def writes(ipmi: IpmiInfo) = JsObject(Seq(
-      "ASSET_ID" -> Json.toJson(ipmi.asset_id),
-      "ASSET_TAG" -> Json.toJson(Asset.findById(ipmi.asset_id).map(_.tag).getOrElse("Unknown")),
+      "ASSET_ID" -> Json.toJson(ipmi.assetId),
+      "ASSET_TAG" -> Json.toJson(Asset.findById(ipmi.assetId).map(_.tag).getOrElse("Unknown")),
       IpmiUsername.toString -> Json.toJson(ipmi.username),
       IpmiPassword.toString -> Json.toJson(ipmi.password),
       IpmiGateway.toString -> Json.toJson(ipmi.dottedGateway),
@@ -73,8 +73,8 @@ object conversions {
       (json \ "ID").asOpt[Long].getOrElse(0L)
     ))
     override def writes(ip: IpAddresses) = JsObject(Seq(
-      "ASSET_ID" -> Json.toJson(ip.asset_id),
-      "ASSET_TAG" -> Json.toJson(Asset.findById(ip.asset_id).map(_.tag).getOrElse("Unknown")),
+      "ASSET_ID" -> Json.toJson(ip.assetId),
+      "ASSET_TAG" -> Json.toJson(Asset.findById(ip.assetId).map(_.tag).getOrElse("Unknown")),
       "GATEWAY" -> Json.toJson(ip.dottedGateway),
       "ADDRESS" -> Json.toJson(ip.dottedAddress),
       "NETMASK" -> Json.toJson(ip.dottedNetmask),

--- a/app/collins/models/shared/CommonHelper.scala
+++ b/app/collins/models/shared/CommonHelper.scala
@@ -48,7 +48,7 @@ trait CommonHelper[T] {
     m.find { _.getMetaId == e.id }.map { i => c(i.getValue) }.getOrElse(d)
   }
   protected def amfinder[T](m: Seq[MetaWrapper], e: AssetMeta, c: (String => T), d: T): T = {
-    m.find { _.getMetaId == e.getId }.map { i => c(i.getValue) }.getOrElse(d)
+    m.find { _.getMetaId == e.id }.map { i => c(i.getValue) }.getOrElse(d)
   }
   protected def seqFinder[T](m: Seq[MetaWrapper], e: AssetMeta.Enum, c: (String => T)): Seq[T] = {
     m.filter(_.getMetaId == e.id).map(i => c(i.getValue))

--- a/app/collins/models/shared/IpAddressable.scala
+++ b/app/collins/models/shared/IpAddressable.scala
@@ -61,11 +61,11 @@ trait IpAddressStorage[T <: IpAddressable] extends Schema with AnormAdapter[T] {
   }
 
   def findAllByAsset(asset: Asset, checkCache: Boolean = true): Seq[T] = inTransaction { 
-    tableDef.where(a => a.asset_id === asset.getId).toList 
+    tableDef.where(a => a.asset_id === asset.id).toList 
   }
 
   def findByAsset(asset: Asset)(implicit mf: Manifest[T]): Option[T] = inTransaction {
-    tableDef.where(a => a.asset_id === asset.getId).headOption
+    tableDef.where(a => a.asset_id === asset.id).headOption
   }
 
   def getNextAvailableAddress(overrideStart: Option[String] = None)(implicit scope: Option[String]): Tuple3[Long,Long,Long] = {

--- a/app/collins/power/management/PowerManagement.scala
+++ b/app/collins/power/management/PowerManagement.scala
@@ -88,13 +88,13 @@ sealed trait PowerManagement  {
   def verify(e: Asset): Future[PowerCommandStatus] = run(e, Verify)
   
   def assetTypeAllowed(asset: Asset): Boolean = {
-    val isTrue = PowerManagementConfig.allowAssetTypes.contains(asset.asset_type)
+    val isTrue = PowerManagementConfig.allowAssetTypes.contains(asset.assetTypeId)
     logger.debug("assetTypeAllowed: %s".format(isTrue.toString))
     isTrue
   }
 
   def assetStateAllowed(asset: Asset): Boolean = {
-    val isFalse = !PowerManagementConfig.disallowStatus.contains(asset.status)
+    val isFalse = !PowerManagementConfig.disallowStatus.contains(asset.statusId)
     logger.debug("assetStateAllowed: %s".format(isFalse.toString))
     isFalse
   }

--- a/app/collins/power/management/PowerManagementConfig.scala
+++ b/app/collins/power/management/PowerManagementConfig.scala
@@ -30,7 +30,7 @@ object PowerManagementConfig extends Configurable {
   object Messages extends MessageHelper(namespace) {
     def assetStateAllowed(a: Asset) = message("disallowStatus", a.getStatusName)
     def actionAllowed(p: PowerAction) = message("disallowWhenAllocated", p.toString)
-    def assetTypeAllowed(a: Asset) = message("allowAssetTypes", a.getType().name)
+    def assetTypeAllowed(a: Asset) = message("allowAssetTypes", a.assetType.name)
   }
 
   def allowAssetTypes: Set[Int] = getStringSet("allowAssetTypes").map { name =>

--- a/app/collins/provisioning/Provisioner.scala
+++ b/app/collins/provisioning/Provisioner.scala
@@ -34,7 +34,7 @@ object Provisioner extends Provisioner {
 
   // overrides ProvisionerInterface.canProvision
   override def canProvision(asset: Asset): Boolean = {
-    ProvisionerConfig.allowedStatus(asset.status) && ProvisionerConfig.allowedType(asset.asset_type)
+    ProvisionerConfig.allowedStatus(asset.statusId) && ProvisionerConfig.allowedType(asset.assetTypeId)
   }
 
   // overrides ProvisionerInterface.provision

--- a/app/collins/solr/CollinsSearchQuery.scala
+++ b/app/collins/solr/CollinsSearchQuery.scala
@@ -47,8 +47,8 @@ abstract class CollinsSearchQuery[T](docType: SolrDocType, query: TypedSolrExpre
     Left("Solr is not initialized!")
   }
 
-  def getPage(): Either[String, Page[T]] = getResults().right.map{case (results, total) =>
-    Page(results, page.page, page.page * page.size, total)
+  def getPage[V](f: Seq[T] => Seq[V] ): Either[String, Page[V]] = getResults().right.map{case (results, total) =>
+    Page(f(results), page.page, page.page * page.size, total)
   }
 
   protected def getSortDirection() = {
@@ -62,14 +62,14 @@ abstract class CollinsSearchQuery[T](docType: SolrDocType, query: TypedSolrExpre
 
 }
 
-case class AssetSearchQuery(query: TypedSolrExpression, page: PageParams) extends CollinsSearchQuery[Asset](AssetDocType, query, page) {
+case class AssetSearchQuery(query: TypedSolrExpression, page: PageParams) extends CollinsSearchQuery[String](AssetDocType, query, page) {
 
-  def parseDocument(doc: SolrDocument) = Asset.findByTag(doc.getFieldValue("TAG").toString)
+  def parseDocument(doc: SolrDocument) = Some(doc.getFieldValue("TAG").toString)
 
 }
 
-case class AssetLogSearchQuery(query: TypedSolrExpression, page: PageParams) extends CollinsSearchQuery[AssetLog](AssetLogDocType, query, page) {
+case class AssetLogSearchQuery(query: TypedSolrExpression, page: PageParams) extends CollinsSearchQuery[Long](AssetLogDocType, query, page) {
 
-  def parseDocument(doc: SolrDocument) = AssetLog.findById(Integer.parseInt(doc.getFieldValue("ID").toString))
+  def parseDocument(doc: SolrDocument) = Some(java.lang.Long.parseLong(doc.getFieldValue("ID").toString))
 
 }

--- a/app/collins/solr/SolrCallbackHandler.scala
+++ b/app/collins/solr/SolrCallbackHandler.scala
@@ -37,7 +37,7 @@ case class SolrAssetCallbackHandler(server: SolrClient, updater: ActorRef) exten
       updater ! a
     }
     case v: AssetMetaValue =>
-      updater ! v.getAsset
+      updater ! v.asset
     case i: IpAddresses =>
       updater ! i.getAsset
     case s: String =>

--- a/app/collins/solr/asset/AssetSerializer.scala
+++ b/app/collins/solr/asset/AssetSerializer.scala
@@ -34,7 +34,7 @@ object AssetSerializer extends SolrSerializer[Asset](AssetDocType) {
     val opt = Map[SolrKey, Option[SolrValue]](
       res("UPDATED").get -> asset.updated.map{t => SolrStringValue(Formatter.solrDateFormat(t), StrictUnquoted)},
       res("DELETED").get -> asset.deleted.map{t => SolrStringValue(Formatter.solrDateFormat(t), StrictUnquoted)},
-      res("STATE").get -> asset.getState.map{s => SolrStringValue(s.name, StrictUnquoted)},
+      res("STATE").get -> asset.state.map{s => SolrStringValue(s.name, StrictUnquoted)},
       res("IP_ADDRESS").get -> {
         val a = IpAddresses.findAllByAsset(asset, false)
         if (a.size > 0) {
@@ -53,8 +53,8 @@ object AssetSerializer extends SolrSerializer[Asset](AssetDocType) {
     opt ++ ipmi ++ Map[SolrKey, SolrValue](
       res("ID").get -> SolrIntValue(asset.id.toInt),
       res("TAG").get -> SolrStringValue(asset.tag, StrictUnquoted),
-      res("STATUS").get -> SolrStringValue(asset.getStatus.name, StrictUnquoted),
-      res("TYPE").get -> SolrStringValue(asset.getType.name, StrictUnquoted),
+      res("STATUS").get -> SolrStringValue(asset.getStatusName, StrictUnquoted),
+      res("TYPE").get -> SolrStringValue(asset.getTypeName, StrictUnquoted),
       res("CREATED").get -> SolrStringValue(Formatter.solrDateFormat(asset.created), StrictUnquoted)
     ) ++ serializeMetaValues(AssetMetaValue.findByAsset(asset, false))
   }

--- a/app/collins/solr/asset/AssetSerializer.scala
+++ b/app/collins/solr/asset/AssetSerializer.scala
@@ -1,4 +1,3 @@
-
 package collins.solr
 
 import java.util.Date
@@ -49,7 +48,7 @@ object AssetSerializer extends SolrSerializer[Asset](AssetDocType) {
     val ipmi: AssetSolrDocument = IpmiInfo.findByAsset(asset).map{ipmi => Map(
       res(IpmiInfo.Enum.IpmiAddress.toString).get -> SolrStringValue(ipmi.dottedAddress, StrictUnquoted)
     )}.getOrElse(Map())
-      
+
     opt ++ ipmi ++ Map[SolrKey, SolrValue](
       res("ID").get -> SolrIntValue(asset.id.toInt),
       res("TAG").get -> SolrStringValue(asset.tag, StrictUnquoted),
@@ -60,7 +59,7 @@ object AssetSerializer extends SolrSerializer[Asset](AssetDocType) {
   }
 
   def getUUID(asset: Asset) = asset.id
-  
+
   //FIXME: The parsing logic here is duplicated in AssetMeta.validateValue
   def serializeMetaValues(values: Seq[MetaWrapper]): AssetSolrDocument = {
     def process(build: AssetSolrDocument, remain: Seq[MetaWrapper]): AssetSolrDocument = remain match {

--- a/app/collins/solr/logs/AssetLogSerializer.scala
+++ b/app/collins/solr/logs/AssetLogSerializer.scala
@@ -17,8 +17,8 @@ object AssetLogSerializer extends SolrSerializer[AssetLog](AssetLogDocType) {
   def getFields(log: AssetLog, indexTime: Date): AssetSolrDocument = Map[SolrKey, SolrValue](
     res("ID").get -> SolrIntValue(log.id.toInt),
     res("MESSAGE").get -> SolrStringValue(log.message, StrictUnquoted),
-    res("MESSAGE_TYPE").get -> SolrStringValue(log.message_type.toString, StrictUnquoted),
-    res("ASSET_TAG").get -> SolrStringValue(log.getAssetTag()),
+    res("MESSAGE_TYPE").get -> SolrStringValue(log.messageType.toString, StrictUnquoted),
+    res("ASSET_TAG").get -> SolrStringValue(log.assetTag),
     res("CREATED").get -> SolrStringValue(Formatter.solrDateFormat(log.created))
   )
 

--- a/app/collins/util/StateMachines.scala
+++ b/app/collins/util/StateMachines.scala
@@ -21,7 +21,7 @@ case class AssetStateMachine(asset: Asset) {
   def decommission(): Option[Asset] = if (canDecommission) {
     val sid = State.Terminated.map(_.id).getOrElse(0)
     // FIXME change to partial update
-    val newAsset = asset.copy(status = Status.Decommissioned.get.id, deleted = Some(new Date().asTimestamp), state = sid)
+    val newAsset = asset.copy(statusId = Status.Decommissioned.get.id, deleted = Some(new Date().asTimestamp), stateId = sid)
     val res = Asset.update(newAsset) match {
       case 1 => Some(newAsset)
       case n => None

--- a/app/collins/util/views/SoftLayerHelper.scala
+++ b/app/collins/util/views/SoftLayerHelper.scala
@@ -26,7 +26,7 @@ object SoftLayerHelper {
   }
 
   def canCancel(asset: Asset): Boolean = {
-    validAsset(asset) && SoftLayerConfig.allowedCancelStatus.contains(asset.status)
+    validAsset(asset) && SoftLayerConfig.allowedCancelStatus.contains(asset.statusId)
   }
 
   def canActivate(asset: Asset): Boolean = {
@@ -35,7 +35,7 @@ object SoftLayerHelper {
 
   protected def validAsset(asset: Asset): Boolean = {
     SoftLayer.isSoftLayerAsset(asset) &&
-      ProvisionerConfig.allowedType(asset.asset_type)
+      ProvisionerConfig.allowedType(asset.assetTypeId)
   }
 
 }

--- a/app/collins/util/views/Summary.scala
+++ b/app/collins/util/views/Summary.scala
@@ -35,19 +35,19 @@ case class AssetSummary(template: String) extends Summarizer[Asset] {
   def getAssetType(asset: Asset): String = {
     asset.isServerNode match {
       case true => "Server"
-      case false => asset.getType().label
+      case false => asset.assetType.label
     }
   }
   def getStatusLabel(asset: Asset): String = {
-    val state_string = asset.getState match {
+    val state_string = asset.state match {
       case Some(st) => ":%s" format st.name
       case None => ""
     }
-    val state_descr = asset.getState match {
+    val state_descr = asset.state match {
       case Some(st) => " - %s" format st.description
       case None => ""
     }
-    val badge_class = asset.getStatus.name match {
+    val badge_class = asset.getStatusName match {
       case "Allocated"                    => "label-primary"
       case "Cancelled" | "Decommissioned" => "label-default"
       case "Maintenance"                  => "label-danger"
@@ -56,7 +56,7 @@ case class AssetSummary(template: String) extends Summarizer[Asset] {
       case "Unallocated"                  => "label-success"
       case _                              => "label-default"
     }
-    "<span data-rel=\"tooltip\" data-original-title=\"" + asset.getStatus.description + state_descr +
+    "<span data-rel=\"tooltip\" data-original-title=\"" + asset.status.description + state_descr +
       "\" data-placement=\"bottom\"  class=\"label " + badge_class + "\">" + asset.getStatusName + state_string + "</span>"
   }
   def getHostname(asset: Asset): String = {

--- a/app/collins/util/views/Titler.scala
+++ b/app/collins/util/views/Titler.scala
@@ -7,7 +7,7 @@ object Titler {
     if (asset.getMetaAttribute("HOSTNAME").isDefined) {
       "Collins | %s - %s".format(asset.getMetaAttribute("HOSTNAME").get.getValue, asset.tag)
     } else {
-      val assetType = asset.getType().label
+      val assetType = asset.assetType.label
       "Collins | %s - %s".format(asset.tag, assetType)
     }
   }

--- a/app/views/admin/cache.scala.html
+++ b/app/views/admin/cache.scala.html
@@ -1,0 +1,48 @@
+@(cacheStats: collins.models.cache.Stats)(implicit flash: Flash, req: Request[AnyContent])
+
+@import collins.util.views.Formatter
+@import collins.util.Stats
+
+@main("Cache Stats") {
+<div class="page-header">
+  <h1>Since <small>@Formatter.dateFormat(Stats.StartupTime)</small></h1>
+</div>
+<div class="row">      
+  <div class="colmd12">      
+    <h3 style="display: inline; float: left;"><a datacollapsible="cacheStats">Cache Stats</a></h3>        
+    <form action="/admin/cache/clear" method="POST"><button type="submit" style="float: right" class="btn btnprimary">Clear Cache</button></form>   
+  </div>       
+       
+  <div class="colmd12">      
+    <table id="cacheStats" class="table tablebordered tablehover tablecondensed">       
+      <tbody>      
+        <tr>       
+          <th>Eviction Count</th>      
+          <td>@cacheStats.evictionCount</td>       
+        </tr>      
+        <tr>       
+          <th>Hit Count</th>       
+          <td>@cacheStats.hitCount</td>        
+        </tr>      
+        <tr>       
+          <th>Hit Rate</th>        
+          <td>@Formatter.forPercent(cacheStats.hitRate) %</td>     
+        </tr>      
+        <tr>       
+          <th>Miss Count</th>      
+          <td>@cacheStats.missCount</td>       
+        </tr>      
+        <tr>       
+          <th>Miss Rate</th>       
+          <td>@Formatter.forPercent(cacheStats.missRate) %</td>        
+        </tr>      
+        <tr>       
+          <th>Request Count</th>       
+          <td>@cacheStats.requestCount</td>        
+        </tr>      
+      </tbody>     
+       
+    </table>       
+  </div>       
+</div>
+}

--- a/app/views/asset/show_overview.scala.html
+++ b/app/views/asset/show_overview.scala.html
@@ -73,8 +73,8 @@
             <td>@aa.asset.getStatus().description</td>
           }
         </tr>
-@if(aa.asset.state != 0) {
-  @State.findById(aa.asset.state).map { state =>
+@if(aa.asset.stateId != 0) {
+  @State.findById(aa.asset.stateId).map { state =>
         <tr>
           <th>Asset State</th>
           <td>@state.label</td>

--- a/app/views/asset/show_overview.scala.html
+++ b/app/views/asset/show_overview.scala.html
@@ -61,16 +61,16 @@
         </tr>
         <tr>
           <th>Asset Type</th>
-          <td>@aa.asset.getType().label</td>
+          <td>@aa.asset.assetType.label</td>
           <td></td>
         </tr>
         <tr class="@statusClassFromAsset(aa.asset)">
           <td><strong>Asset Status</strong></td>
-          <td>@aa.asset.getStatus().name</td>
+          <td>@aa.asset.getStatusName</td>
           @if(aa.asset.isMaintenance) {
-            <td><a href="#user-log-section"><span class="label label-primary">See Notes</span></a> @aa.asset.getStatus().description</td>
+            <td><a href="#user-log-section"><span class="label label-primary">See Notes</span></a> @aa.asset.status.description</td>
           } else {
-            <td>@aa.asset.getStatus().description</td>
+            <td>@aa.asset.status.description</td>
           }
         </tr>
 @if(aa.asset.stateId != 0) {

--- a/app/views/resources/intake.scala.html
+++ b/app/views/resources/intake.scala.html
@@ -15,7 +15,7 @@
     <h4 class="alert-heading">Did the correct light come on?</h4>
     <div class="btn-group">
       <a class="btn btn-default" data-altkey="no" href="@collins.app.routes.HelpPage.index(Help.IpmiNoLight)#ipmiNoLight">No</a>
-      <a class="btn btn-primary" data-altkey="yes" href="@collins.app.routes.Resources.intake(asset.getId, 1)?light=yes">Yes</a>
+      <a class="btn btn-primary" data-altkey="yes" href="@collins.app.routes.Resources.intake(asset.id, 1)?light=yes">Yes</a>
     </div>
   </div>
 </div>

--- a/app/views/resources/intake2.scala.html
+++ b/app/views/resources/intake2.scala.html
@@ -17,7 +17,7 @@
     <h4>Scan the Chassis Tag</h4>
     <div class="row">
       <div class="col-lg-5 col-md-6 col-sm-7 col-xs-9">
-      @form(collins.app.routes.Resources.intake(asset.getId, 2)) {
+      @form(collins.app.routes.Resources.intake(asset.id, 2)) {
         @formFieldRow {
           @formLabelInline(f(ChassisTag.toString).name, "Chassis Tag")
           @formInputInline {

--- a/app/views/resources/intake3.scala.html
+++ b/app/views/resources/intake3.scala.html
@@ -33,7 +33,7 @@
 </div>
 <div class="row">
   <div class="col-lg-5 col-md-6 col-sm-7 col-xs-9">
-    @form(collins.app.routes.Resources.intake(asset.getId, 3)) {
+    @form(collins.app.routes.Resources.intake(asset.id, 3)) {
     @formFieldRow {
       @formLabelInline("ASSET_TAG", "Asset Tag")
       @formInputInline {

--- a/conf/docker/permissions.yaml
+++ b/conf/docker/permissions.yaml
@@ -22,6 +22,7 @@ permissions:
     - "g=sre"
     - "u=admins"
     - "u=tools"
+  controllers.Admin.cache:
   controllers.Admin.stats:
   controllers.AssetLogApi.getAllLogData:
     - "g=infra"

--- a/conf/permissions.yaml
+++ b/conf/permissions.yaml
@@ -22,6 +22,7 @@ permissions:
     - "g=sre"
     - "u=admins"
     - "u=tools"
+  controllers.Admin.cache:
   controllers.Admin.stats:
   controllers.AssetLogApi.getAllLogData:
     - "g=infra"

--- a/conf/reference/cache_reference.conf
+++ b/conf/reference/cache_reference.conf
@@ -1,4 +1,4 @@
 cache {
   enabled=true
-  specification="maximumSize=10000,expireAfterWrite=10s"
+  specification="maximumSize=10000,expireAfterWrite=10s,recordStats"
 }

--- a/conf/reference/cache_reference.conf
+++ b/conf/reference/cache_reference.conf
@@ -1,4 +1,4 @@
 cache {
-  class = "collins.cache.GuavaCache"
-  timeout = 10 minutes
+  enabled=true
+  specification="maximumSize=10000,expireAfterWrite=10s"
 }

--- a/conf/routes
+++ b/conf/routes
@@ -26,6 +26,8 @@ GET     /asset/:tag/similar         collins.app.Resources.similar(tag: String, p
 
 # Admin pages
 GET     /admin/stats                collins.controllers.Admin.stats
+GET     /admin/cache                collins.controllers.Admin.cache
+POST    /admin/cache/clear          collins.controllers.Admin.clearCache
 GET     /admin/logs                 collins.controllers.Admin.logs
 GET     /admin/solr                 collins.controllers.Admin.populateSolr
 

--- a/conf/validations.conf
+++ b/conf/validations.conf
@@ -1,4 +1,7 @@
 config.validations = [
+  collins.util.config.MultiCollinsConfig,
+  collins.util.config.Feature,
+  collins.cache.CacheConfig,
   collins.callbacks.CallbackConfig,
   collins.graphs.GraphConfig,
   collins.power.management.PowerManagementConfig,
@@ -8,8 +11,6 @@ config.validations = [
   collins.models.shared.IpAddressConfig,
   collins.models.shared.QueryLogConfig,
   collins.util.config.CryptoConfig,
-  collins.util.config.MultiCollinsConfig,
-  collins.util.config.Feature,
   collins.util.config.IpmiConfig,
   collins.util.config.LshwConfig,
   collins.util.config.LldpConfig,

--- a/test/collins/models/AssetLogSpec.scala
+++ b/test/collins/models/AssetLogSpec.scala
@@ -2,7 +2,7 @@ package collins.models
 
 import collins.models.logs._
 import org.specs2._
-import specification._
+import org.specs2.specification._
 import play.api.test.WithApplication
 
 class AssetLogSpec extends mutable.Specification {
@@ -12,7 +12,7 @@ class AssetLogSpec extends mutable.Specification {
   args(sequential = true)
 
   "The AssetLog Model" should {
-    
+
     "should create" in new WithApplication {
       "scoped" in new mocklog {
         val result = AssetLog.create(newLog)
@@ -37,7 +37,7 @@ class AssetLogSpec extends mutable.Specification {
           logs.items(0).getFormat mustEqual format
           logs.items(0).message mustEqual msg
         }
-        
+
         "find with a negating filter and no asset" in new concretelog {
           AssetLog.create(newLog)
           val alert = AssetLog.list(None,0,10,"DESC","!Informational")
@@ -93,7 +93,7 @@ class AssetLogSpec extends mutable.Specification {
       Asset.findByTag(tag).get
     }
     def asset = Asset.findByTag(tag) match {
-      case None => createAsset
+      case None    => createAsset
       case Some(a) => a
     }
     def asset_id = asset.id

--- a/test/collins/models/AssetLogSpec.scala
+++ b/test/collins/models/AssetLogSpec.scala
@@ -62,7 +62,7 @@ class AssetLogSpec extends mutable.Specification {
           AssetLog.list(Some(asset),0,10,"DESC","Alert").total mustEqual 0
           val info = AssetLog.list(Some(asset),0,10,"DESC","Informational")
           info.total mustEqual 1
-          info.items(0).getAssetId mustEqual asset_id
+          info.items(0).assetId mustEqual asset_id
         }
 
         "find with a negating filter and an asset" in new mocklog {
@@ -70,16 +70,16 @@ class AssetLogSpec extends mutable.Specification {
           val alert = AssetLog.list(Some(asset),0,10,"DESC","!Informational")
           alert.total mustEqual 1
           alert.items(0).isAlert must beTrue
-          alert.items(0).getAssetId mustEqual asset_id
+          alert.items(0).assetId mustEqual asset_id
           AssetLog.list(Some(asset),0,10,"DESC","!Alert").total mustEqual 0
         }
 
         "find with a sort" in new concretelog {
           AssetLog.create(newLog)
           val desc = AssetLog.list(None, 0, 10, "DESC")
-          desc.items(0).getId must be_>(desc.items(1).getId)
+          desc.items(0).id must be_>(desc.items(1).id)
           val asc = AssetLog.list(None, 0, 10, "ASC")
-          asc.items(0).getId must be_<(asc.items(1).getId)
+          asc.items(0).id must be_<(asc.items(1).id)
         }
 
       } // support getters/finders
@@ -96,7 +96,7 @@ class AssetLogSpec extends mutable.Specification {
       case None => createAsset
       case Some(a) => a
     }
-    def asset_id = asset.getId
+    def asset_id = asset.id
     def msg = "Hello World"
     def format = LogFormat.PlainText
     def source = LogSource.Internal

--- a/test/collins/models/AssetMetaSpec.scala
+++ b/test/collins/models/AssetMetaSpec.scala
@@ -53,7 +53,7 @@ class AssetMetaSpec extends mutable.Specification {
       "DELETE" in new mockassetmeta {
         AssetMeta.findByName(metaName).map { a =>
           AssetMeta.delete(a) mustEqual 1
-          AssetMeta.findById(a.getId) must beNone
+          AssetMeta.findById(a.id) must beNone
         }.getOrElse(failure("Couldn't find asset meta but expected to"))
       }
     }

--- a/test/collins/models/AssetSpec.scala
+++ b/test/collins/models/AssetSpec.scala
@@ -17,7 +17,7 @@ class AssetSpec extends mutable.Specification {
 
       "CREATE" in new mockasset {
         val result = Asset.create(newAsset)
-        result.getId must beGreaterThan(1L)
+        result.id must beGreaterThan(1L)
       }
 
       "UPDATE" in new mockasset {
@@ -26,14 +26,14 @@ class AssetSpec extends mutable.Specification {
         val realAsset = maybeAsset.get
         Asset.update(realAsset.copy(statusId = Status.New.get.id))
         Asset.findByTag(assetTag).map { a =>
-          a.getStatus().getId mustEqual(Status.New.get.id)
+          a.status.id mustEqual(Status.New.get.id)
         }.getOrElse(failure("Couldn't find asset but expected to"))
       }
 
       "DELETE" in new mockasset {
         Asset.findByTag(assetTag).map { a =>
           Asset.delete(a) mustEqual 1
-          Asset.findById(a.getId) must beNone
+          Asset.findById(a.id) must beNone
         }.getOrElse(failure("Couldn't find asset but expected to"))
       }
     }

--- a/test/collins/models/AssetSpec.scala
+++ b/test/collins/models/AssetSpec.scala
@@ -24,7 +24,7 @@ class AssetSpec extends mutable.Specification {
         val maybeAsset = Asset.findByTag(assetTag)
         maybeAsset must beSome[Asset]
         val realAsset = maybeAsset.get
-        Asset.update(realAsset.copy(status = Status.New.get.id))
+        Asset.update(realAsset.copy(statusId = Status.New.get.id))
         Asset.findByTag(assetTag).map { a =>
           a.getStatus().getId mustEqual(Status.New.get.id)
         }.getOrElse(failure("Couldn't find asset but expected to"))

--- a/test/collins/models/CommonHelperSpec.scala
+++ b/test/collins/models/CommonHelperSpec.scala
@@ -25,8 +25,8 @@ trait CommonHelperSpec[REP] extends collins.ResourceFinder {
     val enums = AssetMeta.Enum.values.toSeq
     val dvals = AssetMeta.DynamicEnum.getValues
     mvs.map { mv =>
-      val mid = mv.asset_meta_id
-      MetaWrapper(AssetMeta.findById(mv.asset_meta_id).get, mv)
+      val mid = mv.assetMetaId
+      MetaWrapper(AssetMeta.findById(mv.assetMetaId).get, mv)
     }
   }
 }

--- a/test/collins/models/MockAssetTools.scala
+++ b/test/collins/models/MockAssetTools.scala
@@ -12,16 +12,18 @@ case class MockRemoteAsset(
   json: JsObject = JsObject(Seq.empty),  
   remoteUrl: String = "http://localhost",
   id: Long = 42L,
-  state: Int = 0
+  stateId: Int = 0
 ) extends RemoteAsset { 
 
   import asset.conversions._
-  def asset_type: Int = AssetType.ServerNode.get.id
-  def status: Int = Status.Allocated.get.id
+  def assetTypeId: Int = AssetType.ServerNode.get.id
+  def statusId: Int = Status.Allocated.get.id
   def created: Timestamp = new Timestamp(System.currentTimeMillis) 
   def updated: Option[Timestamp] =  None 
   def deleted: Option[Timestamp] = None
  
+  def getStateName(): String = ""
+  def getTypeName(): String = ""
   def getHostnameMetaValue(): Option[String] = None 
   def getPrimaryRoleMetaValue(): Option[String] = None 
   def getMetaAttributeValue(name: String): Option[String] = None

--- a/test/collins/models/cache/CacheSpec.scala
+++ b/test/collins/models/cache/CacheSpec.scala
@@ -1,0 +1,258 @@
+package collins.models.cache
+
+import org.specs2.mutable
+import play.api.test.WithApplication
+
+import collins.util.IpAddress
+
+import collins.models.Asset
+import collins.models.AssetMeta
+import collins.models.AssetMetaValue
+import collins.models.AssetType
+import collins.models.IpmiInfo
+import collins.models.State
+import collins.models.Status
+import collins.models.IpAddresses
+
+/*
+ * This specification relies heavily on migrations to populate the database
+ */
+class CacheSpec extends mutable.Specification {
+
+  "Cache Specification".title
+
+  args(sequential = true)
+
+  "Basic cache operations " should {
+    "return None when looking for an element not populated in cache " in new WithApplication {
+      val assetFromCache = Cache.get[Option[Asset]](Asset.findByTagKey("notincache"))
+      assetFromCache mustEqual None
+    }
+  }
+
+  "Assets must be cached" in {
+
+    "during find for non existing asset cache should be populated with None" in new WithApplication {
+      val maybeAsset = Asset.findByTag("cacheasset1")
+      maybeAsset mustEqual None
+      val assetFromCache = Cache.get[Option[Asset]](Asset.findByTagKey("cacheasset1"))
+      assetFromCache mustEqual Some(None)
+    }
+
+    "after a create asset must be found in cache using tag" in new WithApplication {
+      val assetTag = "cacheasset1"
+      val maybeAsset = Asset.findByTag(assetTag)
+      maybeAsset mustEqual None
+      val assetFromCache = Cache.get[Option[Asset]](Asset.findByTagKey(assetTag))
+      assetFromCache mustEqual Some(None)
+
+      val asset = Asset.create(Asset(assetTag, Status.Incomplete.get, AssetType.ServerNode.get))
+      val afterCreateMaybeAsset = Asset.findByTag(assetTag)
+      afterCreateMaybeAsset mustEqual Some(asset)
+      val afterCreateAssetFromCache = Cache.get[Option[Asset]](Asset.findByTagKey(assetTag))
+      afterCreateAssetFromCache mustEqual Some(Some(asset))
+    }
+
+    "after a create asset must be found in cache using id" in new WithApplication {
+      val assetTag = "cacheasset1"
+      val maybeAsset = Asset.findByTag(assetTag)
+      maybeAsset mustEqual None
+      val assetFromCache = Cache.get[Option[Asset]](Asset.findByTagKey(assetTag))
+      assetFromCache mustEqual Some(None)
+
+      val asset = Asset.create(Asset(assetTag, Status.Incomplete.get, AssetType.ServerNode.get))
+      val afterCreateMaybeAsset = Asset.findById(asset.id)
+      afterCreateMaybeAsset mustEqual Some(asset)
+      val afterCreateAssetFromCache = Cache.get[Option[Asset]](Asset.findByIdKey(asset.id))
+      afterCreateAssetFromCache mustEqual Some(Some(asset))
+    }
+  }
+
+  "AssetMeta must be cached" in {
+    "find pre-populated asset meta" in new WithApplication {
+      val metas = AssetMeta.findAll()
+      val metasFromCache = Cache.get[List[AssetMeta]](AssetMeta.findByAllKey)
+      metasFromCache mustEqual Some(metas)
+    }
+
+    "find pre-populated asset meta by name" in new WithApplication {
+      val meta = AssetMeta.findAll().head
+      val sameMeta = AssetMeta.findByName(meta.name)
+      sameMeta mustEqual Some(meta)
+
+      val metaFromCache = Cache.get[Option[AssetMeta]](AssetMeta.findByNameKey(meta.name))
+      metaFromCache mustEqual Some(Some(meta))
+    }
+
+    "find pre-populated asset meta by id" in new WithApplication {
+      val meta = AssetMeta.findAll().head
+      val sameMeta = AssetMeta.findById(meta.id)
+      sameMeta mustEqual Some(meta)
+
+      val metaFromCache = Cache.get[Option[AssetMeta]](AssetMeta.findByIdKey(meta.id))
+      metaFromCache mustEqual Some(Some(meta))
+    }
+
+    "find pre-populated by viewabled " in new WithApplication {
+      val metas = AssetMeta.getViewable()
+      val metasFromCache = Cache.get[List[AssetMeta]](AssetMeta.findByViewableKey)
+      metasFromCache mustEqual Some(metas)
+    }
+  }
+
+  "AssetType must be cached" in {
+    "find pre-populated asset types" in new WithApplication {
+      val types = AssetType.find
+      val typesFromCache = Cache.get[Option[List[AssetType]]](AssetType.findKey)
+      typesFromCache mustEqual Some(types)
+    }
+
+    "find pre-populated asset type by name" in new WithApplication {
+      val assetType = AssetType.find.head
+      val sameType = AssetType.findByName(assetType.name)
+      sameType mustEqual Some(assetType)
+
+      val typeFromCache = Cache.get[Option[AssetType]](AssetType.findByNameKey(assetType.name))
+      typeFromCache mustEqual Some(Some(assetType))
+    }
+
+    "find pre-populated asset type by id" in new WithApplication {
+      val assetType = AssetType.find.head
+      val sameType = AssetType.findById(assetType.id)
+      sameType mustEqual Some(assetType)
+
+      val typeFromCache = Cache.get[Option[AssetType]](AssetType.findByIdKey(assetType.id))
+      typeFromCache mustEqual Some(Some(assetType))
+    }
+  }
+
+  "State must be cached" in {
+    "find pre-populated states" in new WithApplication {
+      val states = State.find
+      val statesFromCache = Cache.get[List[State]](State.findKey)
+      statesFromCache mustEqual Some(states)
+    }
+
+    "find pre-populated state by name" in new WithApplication {
+      val state = State.find.head
+      val sameState = State.findByName(state.name)
+      sameState mustEqual Some(state)
+
+      val stateFromCache = Cache.get[Option[State]](State.findByNameKey(state.name))
+      stateFromCache mustEqual Some(Some(state))
+    }
+
+    "find pre-populated state by id" in new WithApplication {
+      val state = State.find.head
+      val sameState = State.findById(state.id)
+      sameState mustEqual Some(state)
+
+      val stateFromCache = Cache.get[Option[State]](State.findByIdKey(state.id))
+      stateFromCache mustEqual Some(Some(state))
+    }
+
+    "find pre-populated state by any status" in new WithApplication {
+      val states = State.findByAnyStatus()
+      states.size mustEqual 6
+      val statesFromCache = Cache.get[List[State]](State.findByAnyStatusKey)
+      statesFromCache mustEqual Some(states)
+    }
+
+    "find pre-populated state by status key" in new WithApplication {
+      val status = Status.Maintenance.get
+      val state = State.findByStatus(status)
+      val stateFromCache = Cache.get[Option[State]](State.findByStatusKey(status.id))
+      stateFromCache mustEqual Some(state)
+    }
+  }
+
+  "AssetMetaValues must be cached" in {
+    "find pre-populated meta value by asset and meta id" in new WithApplication {
+      val asset = Asset.findById(1).get
+      val assetMeta = AssetMeta.findById(1).get
+      val metaValues = AssetMetaValue.findByAssetAndMeta(asset, assetMeta, 10)
+      val metaValuesFromCache = Cache.get[List[AssetMetaValue]](AssetMetaValue.findByAssetAndMetaKey(asset.id, assetMeta.id))
+      metaValuesFromCache mustEqual Some(metaValues)
+
+      // using method from Asset
+      val firstMetaValue = asset.getMetaAttribute(assetMeta.name)
+      firstMetaValue mustEqual metaValuesFromCache.get.headOption
+      firstMetaValue mustEqual metaValues.headOption
+    }
+
+    "find pre-populated meta value by asset" in new WithApplication {
+      val asset = Asset.findById(1).get
+      val metaValues = AssetMetaValue.findByAsset(asset)
+      val metaValuesFromCache = Cache.get[List[AssetMetaValue]](AssetMetaValue.findByAssetKey(asset.id))
+      metaValuesFromCache mustEqual Some(metaValues)
+    }
+
+    "find pre-populated meta value by meta" in new WithApplication {
+      val assetMeta = AssetMeta.findById(1).get
+      val metaValues = AssetMetaValue.findByMeta(assetMeta)
+      val metaValuesFromCache = Cache.get[List[AssetMetaValue]](AssetMetaValue.findByMetaKey(assetMeta.id))
+      metaValuesFromCache mustEqual Some(metaValues)
+    }
+  }
+
+  "IpmiInfo must be cached" in {
+
+    "find pre-populated ipmi info by asset" in new WithApplication {
+      val asset = Asset.findById(1).get
+      val ipmiInfo = IpmiInfo.findByAsset(asset)
+      val ipmiInfoFromCache = Cache.get[Option[IpmiInfo]](IpmiInfo.findByAssetKey(asset.id))
+      ipmiInfoFromCache mustEqual Some(ipmiInfo)
+    }
+
+    "find pre-populated all ipmi info by asset" in new WithApplication {
+      val asset = Asset.findById(1).get
+      val ipmiInfo = IpmiInfo.findAllByAsset(asset)
+      val ipmiInfoFromCache = Cache.get[List[IpmiInfo]](IpmiInfo.findAllByAssetKey(asset.id))
+      ipmiInfoFromCache mustEqual Some(ipmiInfo)
+    }
+
+    "find pre-populated ipmi info by id" in new WithApplication {
+      val ipmiInfo = IpmiInfo.get(IpmiInfo(1, "test-user", "", 167772161L, 167772162L, 4294959104L, 1))
+      val ipmiInfoFromCache = Cache.get[Option[IpmiInfo]](IpmiInfo.findByIdKey(ipmiInfo.id))
+      ipmiInfoFromCache mustEqual Some(ipmiInfo)
+    }
+  }
+
+  "IpAddress must be cached" in {
+    "find ip address by asset" in new WithApplication {
+      val asset = Asset.findById(1).get
+      IpAddresses.create(IpAddresses(asset.id, IpAddress.toLong("10.0.0.1"),
+        IpAddress.toLong("10.0.0.2"), IpAddress.toLong("255.255.224.0"), "fortesting"))
+      val address = IpAddresses.findByAsset(asset)
+      val addressFromCache = Cache.get[Option[IpAddresses]](IpAddresses.findByAssetKey(asset.id))
+      addressFromCache mustEqual Some(address)
+    }
+
+    "find all ip address by asset" in new WithApplication {
+      val asset = Asset.findById(1).get
+      IpAddresses.create(IpAddresses(asset.id, IpAddress.toLong("10.0.0.1"),
+        IpAddress.toLong("10.0.0.2"), IpAddress.toLong("255.255.224.0"), "fortesting"))
+      val addresses = IpAddresses.findAllByAsset(asset)
+      val addressesFromCache = Cache.get[Option[List[IpAddresses]]](IpAddresses.findAllByAssetKey(asset.id))
+      addressesFromCache mustEqual Some(addresses)
+    }
+
+    "find ip address by id" in new WithApplication {
+      val asset = Asset.findById(1).get
+      val address = IpAddresses.get(IpAddresses.create(IpAddresses(asset.id, IpAddress.toLong("10.0.0.1"),
+        IpAddress.toLong("10.0.0.2"), IpAddress.toLong("255.255.224.0"), "fortesting")))
+      val addressFromCache = Cache.get[Option[IpAddresses]](IpAddresses.findByIdKey(address.id))
+      addressFromCache mustEqual Some(address)
+    }
+
+    "find pools in use" in new WithApplication {
+      val asset = Asset.findById(1).get
+      IpAddresses.create(IpAddresses(asset.id, IpAddress.toLong("10.0.0.1"),
+        IpAddress.toLong("10.0.0.2"), IpAddress.toLong("255.255.224.0"), "fortesting"))
+      val pools = IpAddresses.getPoolsInUse()
+      pools mustEqual Set("fortesting")
+      val poolsFromCache = Cache.get[Option[IpAddresses]](IpAddresses.findPoolsInUseKey)
+      poolsFromCache mustEqual Some(pools)
+    }
+  }
+}

--- a/test/collins/util/SolrSpec.scala
+++ b/test/collins/util/SolrSpec.scala
@@ -176,7 +176,7 @@ class SolrSpec extends mutable.Specification {
       page.items.size mustEqual 1
       page.items.headOption must beSome.which { asset =>
         asset.tag mustEqual assetTag
-        asset.statusId mustEqual Status.Allocated.get.getId()
+        asset.statusId mustEqual Status.Allocated.get.id
       }
     }
     
@@ -202,7 +202,7 @@ class SolrSpec extends mutable.Specification {
       page.items.size mustEqual 1
       page.items.headOption must beSome.which { asset =>
         asset.tag mustEqual assetTag
-        asset.statusId mustEqual Status.Allocated.get.getId()
+        asset.statusId mustEqual Status.Allocated.get.id
       }
     }
     
@@ -228,7 +228,7 @@ class SolrSpec extends mutable.Specification {
       page.items.size mustEqual 1
       page.items.headOption must beSome.which { asset =>
         asset.tag mustEqual assetTag
-        asset.statusId mustEqual Status.Allocated.get.getId()
+        asset.statusId mustEqual Status.Allocated.get.id
       }
     }
     
@@ -254,7 +254,7 @@ class SolrSpec extends mutable.Specification {
       page.items.size mustEqual 1
       page.items.headOption must beSome.which { asset =>
         asset.tag mustEqual assetTag
-        asset.statusId mustEqual Status.Allocated.get.getId()
+        asset.statusId mustEqual Status.Allocated.get.id
       }
     }
     
@@ -280,7 +280,7 @@ class SolrSpec extends mutable.Specification {
       page.items.size mustEqual 1
       page.items.headOption must beSome.which { asset =>
         asset.tag mustEqual assetTag
-        asset.statusId mustEqual Status.Allocated.get.getId()
+        asset.statusId mustEqual Status.Allocated.get.id
       }
     }
     
@@ -304,13 +304,13 @@ class SolrSpec extends mutable.Specification {
       page.items.size mustEqual 2
       page.items.find { a => a.tag == assetTag } must beSome.which { asset =>
         asset.tag mustEqual assetTag
-        asset.statusId mustEqual Status.Allocated.get.getId()
+        asset.statusId mustEqual Status.Allocated.get.id
         asset.getMetaAttributeValue("T") mustEqual Some("T")
         asset.getMetaAttributeValue("U") mustEqual None
       }
       page.items.find { a => a.tag == assetTag2 } must beSome.which { asset =>
         asset.tag mustEqual assetTag2
-        asset.statusId mustEqual Status.Provisioned.get.getId()
+        asset.statusId mustEqual Status.Provisioned.get.id
         asset.getMetaAttributeValue("T") mustEqual None
         asset.getMetaAttributeValue("U") mustEqual Some("U")
       }
@@ -335,7 +335,7 @@ class SolrSpec extends mutable.Specification {
       page.items.size mustEqual 1
       page.items.find { a => a.tag == assetTag } must beSome.which { asset =>
         asset.tag mustEqual assetTag
-        asset.statusId mustEqual Status.Allocated.get.getId()
+        asset.statusId mustEqual Status.Allocated.get.id
          asset.getMetaAttributeValue("SPECIFICATION") mustEqual Some("WEB SERVICE FURY HADOOP")
       }
     }

--- a/test/collins/util/SolrSpec.scala
+++ b/test/collins/util/SolrSpec.scala
@@ -176,7 +176,7 @@ class SolrSpec extends mutable.Specification {
       page.items.size mustEqual 1
       page.items.headOption must beSome.which { asset =>
         asset.tag mustEqual assetTag
-        asset.status mustEqual Status.Allocated.get.getId()
+        asset.statusId mustEqual Status.Allocated.get.getId()
       }
     }
     
@@ -202,7 +202,7 @@ class SolrSpec extends mutable.Specification {
       page.items.size mustEqual 1
       page.items.headOption must beSome.which { asset =>
         asset.tag mustEqual assetTag
-        asset.status mustEqual Status.Allocated.get.getId()
+        asset.statusId mustEqual Status.Allocated.get.getId()
       }
     }
     
@@ -228,7 +228,7 @@ class SolrSpec extends mutable.Specification {
       page.items.size mustEqual 1
       page.items.headOption must beSome.which { asset =>
         asset.tag mustEqual assetTag
-        asset.status mustEqual Status.Allocated.get.getId()
+        asset.statusId mustEqual Status.Allocated.get.getId()
       }
     }
     
@@ -254,7 +254,7 @@ class SolrSpec extends mutable.Specification {
       page.items.size mustEqual 1
       page.items.headOption must beSome.which { asset =>
         asset.tag mustEqual assetTag
-        asset.status mustEqual Status.Allocated.get.getId()
+        asset.statusId mustEqual Status.Allocated.get.getId()
       }
     }
     
@@ -280,7 +280,7 @@ class SolrSpec extends mutable.Specification {
       page.items.size mustEqual 1
       page.items.headOption must beSome.which { asset =>
         asset.tag mustEqual assetTag
-        asset.status mustEqual Status.Allocated.get.getId()
+        asset.statusId mustEqual Status.Allocated.get.getId()
       }
     }
     
@@ -304,13 +304,13 @@ class SolrSpec extends mutable.Specification {
       page.items.size mustEqual 2
       page.items.find { a => a.tag == assetTag } must beSome.which { asset =>
         asset.tag mustEqual assetTag
-        asset.status mustEqual Status.Allocated.get.getId()
+        asset.statusId mustEqual Status.Allocated.get.getId()
         asset.getMetaAttributeValue("T") mustEqual Some("T")
         asset.getMetaAttributeValue("U") mustEqual None
       }
       page.items.find { a => a.tag == assetTag2 } must beSome.which { asset =>
         asset.tag mustEqual assetTag2
-        asset.status mustEqual Status.Provisioned.get.getId()
+        asset.statusId mustEqual Status.Provisioned.get.getId()
         asset.getMetaAttributeValue("T") mustEqual None
         asset.getMetaAttributeValue("U") mustEqual Some("U")
       }
@@ -335,7 +335,7 @@ class SolrSpec extends mutable.Specification {
       page.items.size mustEqual 1
       page.items.find { a => a.tag == assetTag } must beSome.which { asset =>
         asset.tag mustEqual assetTag
-        asset.status mustEqual Status.Allocated.get.getId()
+        asset.statusId mustEqual Status.Allocated.get.getId()
          asset.getMetaAttributeValue("SPECIFICATION") mustEqual Some("WEB SERVICE FURY HADOOP")
       }
     }


### PR DESCRIPTION
In testing in production, it was necessary to have domain model
caching to avoid overwhelming the db with queries. This commit
introduces caching back for domain models, in doing so makes
the code more type checkable and adds fairly substantial and
complete unit test.

This also make the following changes. 

(a) When returning the results for a Asset.find call, load all assets 
from database using a single query

(b) Use transient for lazy vals and caching of queries objects to 
avoid making a db call for each invocation (where applicable)

(c) Introduce a permission to clear cache.

(d) Minor changes for uniform property access.

@Primer42 @defect @byxorna @roymarantz 
