### PR TITLE
Handle leading/trailing white space in top search bar field.

### DIFF
--- a/app/collins/controllers/actions/asset/AssetFinderDataHolder.scala
+++ b/app/collins/controllers/actions/asset/AssetFinderDataHolder.scala
@@ -88,7 +88,7 @@ object AssetFinderDataHolder extends MessageHelper("assetfinder") with Attribute
   def processRequest(req: Request[AnyContent]): Either[RequestDataHolder,AssetFinderDataHolder] = {
     processForm(finderForm.bindFromRequest()(req), req.queryString)
   }
-    
+
   protected def processForm(form: Form[DataForm], data: Map[String,Seq[String]]): Either[RequestDataHolder,AssetFinderDataHolder] = {
     form.fold(
       err => Left(RequestDataHolder.error400(fieldError(err))),
@@ -134,6 +134,7 @@ object AssetFinderDataHolder extends MessageHelper("assetfinder") with Attribute
     case e if e.error("details").isDefined => rootMessage("error.truthy", "details")
     case e if e.error("remoteLookup").isDefined => rootMessage("error.truthy", "remoteLookup")
     case e if e.error("state").isDefined => rootMessage("asset.state.invalid")
+    case e if e.error("query").isDefined => message("query.invalid")
     case n => "Unexpected error occurred"
   }
 

--- a/app/collins/controllers/forms.scala
+++ b/app/collins/controllers/forms.scala
@@ -101,7 +101,7 @@ package object forms {
     def bind(key: String, data: Map[String, String]) = {
       Formats.stringFormat.bind(key, data).right.flatMap { qry =>
         allCatch[SolrExpression]
-          .either(parseQuery(qry).right.get)
+          .either(parseQuery(qry.trim).right.get)
           .left.map(_ => Seq(FormError(key, "query.invalid", Nil)))
       }
     }

--- a/conf/messages
+++ b/conf/messages
@@ -37,6 +37,7 @@ assetfinder.tag.invalid=An asset tag must be at least 1 character.
 assetfinder.type.invalid=Invalid asset type specified.
 assetfinder.date.invalid={0} must be an ISO 8601 date format like ''{1}''.
 assetfinder.operation.invalid=Invalid operation specified. Valid operations are ''and'' or ''or''.
+assetfinder.query.invalid=Invalid Collins Query syntax.
 
 assetlog.create.error.messageInvalid=message parameter must not be empty
 assetlog.create.error.messageTypeInvalid=specified log type is invalid, valid types are: {0}

--- a/test/collins/controllers/FormsSpec.scala
+++ b/test/collins/controllers/FormsSpec.scala
@@ -6,19 +6,24 @@ import specification._
 import collins.controllers.forms._
 
 class FormsSpec extends mutable.Specification {
-  
+
   "Solr expression format should correctly bind a valid query" in {
     val result = SolrExpressionFormat.bind("query", Map("query" -> "tag=TRQ* AND name=SomeThing"))
     result must beRight
   }
-  
+
   "Solr expression format should return errors on invalid query" in {
     val result = SolrExpressionFormat.bind("query", Map("query" -> "!A#!!"))
     result must beLeft
   }
-  
+
   "Solr expression format must return valid query by interpreting as a tag" in {
     val result = SolrExpressionFormat.bind("query", Map("query" -> "TRQ12"))
+    result must beRight
+  }
+
+  "Solr expression format must return valid query by interpreting as a tag with whitespace" in {
+    val result = SolrExpressionFormat.bind("query", Map("query" -> "  TRQ12  "))
     result must beRight
   }
 }


### PR DESCRIPTION
Summary:
Leading/trailing white space in top search bar field resulted in
"unexpected error occurred", trim the white space. Additionally
display a correct error message when the query in invalid.

@byxorna @Primer42 @defect @roymarantz 