### PR TITLE
Only fetch the required fields from solr.

### DIFF
--- a/app/collins/solr/CollinsSearchQuery.scala
+++ b/app/collins/solr/CollinsSearchQuery.scala
@@ -29,6 +29,7 @@ abstract class CollinsSearchQuery[T](docType: SolrDocType, query: TypedSolrExpre
       q.setQuery(queryString)
       q.setStart(page.offset)
       q.setRows(page.size)
+      q.setFields(docType.fetchFields)
       q.addSort(new SolrQuery.SortClause(sortKey.resolvedName, getSortDirection))
       try {
         val response = server.query(q)

--- a/app/collins/solr/SolrDocType.scala
+++ b/app/collins/solr/SolrDocType.scala
@@ -3,15 +3,17 @@ package collins.solr
 sealed trait SolrDocType {
   def name: String
   def keyResolver: SolrKeyResolver
-  
+  def fetchFields: String
 }
 
 case object AssetDocType extends SolrDocType {
   val name = "ASSET"
   val keyResolver = AssetKeyResolver
+  val fetchFields = "TAG"
 }
 
 case object AssetLogDocType extends SolrDocType {
   val name = "ASSET_LOG"
   val keyResolver = AssetLogKeyResolver
+  val fetchFields = "ID"
 }


### PR DESCRIPTION
Summary:
See AssetSearchQuery and AssetLogSearchQuery, we only rely on specific
fields. Fetch only these fields and not the entire document.

@byxorna @Primer42 @roymarantz 

TODO: Needs some real world testing.