### PR TITLE
Adding additional stats.

### DIFF
--- a/app/collins/models/Asset.scala
+++ b/app/collins/models/Asset.scala
@@ -216,7 +216,7 @@ object Asset extends Schema with AnormAdapter[Asset] with AssetKeys {
   // Loads assets from cache, then database if not available in cache.
   // Asset are loaded from database using 'in' clause, and are added to cache
   // Returns assets in the order requested, i.e. tag order in params
-  def findByTags(tags: Seq[String]) = {
+  def findByTags(tags: Seq[String]) = Stats.time("Asset.findByTags") {
     val ltags = tags.map { _.toLowerCase }
     val assetOpts = ltags.map { tag => tag -> Cache.get[Option[Asset]](findByTagKey(tag)) }.toMap
     val loadedAssets = inTransaction { from(tableDef)(s =>

--- a/app/collins/solr/CollinsSearchQuery.scala
+++ b/app/collins/solr/CollinsSearchQuery.scala
@@ -5,6 +5,8 @@ import org.apache.solr.common.SolrDocument
 
 import play.api.Logger
 
+import collins.util.Stats
+
 import collins.models.Asset
 import collins.models.AssetLog
 import collins.models.shared.Page
@@ -48,8 +50,11 @@ abstract class CollinsSearchQuery[T](docType: SolrDocType, query: TypedSolrExpre
     Left("Solr is not initialized!")
   }
 
-  def getPage[V](f: Seq[T] => Seq[V] ): Either[String, Page[V]] = getResults().right.map{case (results, total) =>
-    Page(f(results), page.page, page.page * page.size, total)
+  def getPage[V](f: Seq[T] => Seq[V]): Either[String, Page[V]] = Stats.time(f"Solr.find-pgs-${page.size}%d") {
+    getResults().right.map {
+      case (results, total) =>
+        Page(f(results), page.page, page.page * page.size, total)
+    }
   }
 
   protected def getSortDirection() = {


### PR DESCRIPTION
Summary:
Adding additional stats to help diagnose issues (if any). Grabbing solr fetch stats by page size (using arbitrary pages will increase the number of stats that would be collected).

@byxorna @defect @roymarantz @Primer42 