### PR TITLE
net-ping > 1.7.2 requires ruby 1.9.3

### DIFF
--- a/support/ruby/consolr/consolr.gemspec
+++ b/support/ruby/consolr/consolr.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "collins_auth", "~> 0.1.2"
-  spec.add_runtime_dependency "net-ping", "~> 1.7.7"
+  spec.add_runtime_dependency "net-ping", "= 1.7.2" # this is the last version that supports ruby 1.9.2
 
   spec.add_development_dependency "rake", "~> 10.4.2"
   spec.add_development_dependency "rspec", "~> 3.3.0"

--- a/support/ruby/consolr/lib/consolr/version.rb
+++ b/support/ruby/consolr/lib/consolr/version.rb
@@ -1,3 +1,3 @@
 module Consolr
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end


### PR DESCRIPTION
Therefore, require 1.7.2 so we can support 1.9.2

@roymarantz @byxorna @maddalab 