### PR TITLE
Running the cache spec for both In-memory and Distributed 

### DIFF
--- a/app/collins/cache/CacheConfig.scala
+++ b/app/collins/cache/CacheConfig.scala
@@ -27,6 +27,10 @@ object CacheConfig extends Configurable {
         if (!HazelcastConfig.enabled) {
           throw new ConfigurationException("Distributed cache uses hazelcast, please enable and configure it.")
         }
+
+        if (HazelcastConfig.members.isEmpty()) {
+          logger.warn("No cluster members found when instantiating distributed cache, treating as single node cache - use in-memory instead")
+        }
       }
     }
   }

--- a/app/collins/hazelcast/HazelcastConfig.scala
+++ b/app/collins/hazelcast/HazelcastConfig.scala
@@ -20,10 +20,6 @@ object HazelcastConfig extends Configurable {
       if (!f.exists() || !f.canRead()) {
         throw new ConfigurationException(f"Cache config file $configFile%s does not exists or is not readable")
       }
-
-      if (members.trim().length() == 0) {
-        throw new ConfigurationException(f"Please specify cache members when clustered, multicast discovery is not supported")
-      }
     }
   }
 }

--- a/app/collins/hazelcast/HazelcastHelper.scala
+++ b/app/collins/hazelcast/HazelcastHelper.scala
@@ -15,9 +15,14 @@ object HazelcastHelper {
     logger.info(s"Initializing hazelcast, enabled - ${HazelcastConfig.enabled}")
     if (HazelcastConfig.enabled) {
       val config = new FileSystemXmlConfig(HazelcastConfig.configFile)
-      val jc = config.getNetworkConfig().getJoin()
-      jc.getTcpIpConfig().setEnabled(true).addMember(HazelcastConfig.members)
-      logger.trace(f"Instantiating hazelcast instance using members ${HazelcastConfig.members}%s")
+
+      if (!HazelcastConfig.members.isEmpty()) {
+        val jc = config.getNetworkConfig().getJoin()
+        jc.getTcpIpConfig().setEnabled(true).addMember(HazelcastConfig.members)
+        logger.trace(f"Instantiating hazelcast instance using members ${HazelcastConfig.members}%s")
+      } else {
+        logger.warn("Instantiating hazelcast instance on single node, on recommended use case for this deployment is for events.")
+      }
       instance = Some(Hazelcast.newHazelcastInstance(config))
     }
   }
@@ -28,5 +33,6 @@ object HazelcastHelper {
 
   def terminateHazelcast() {
     Hazelcast.shutdownAll()
+    instance = None
   }
 }

--- a/app/collins/models/cache/Cache.scala
+++ b/app/collins/models/cache/Cache.scala
@@ -187,6 +187,7 @@ object Cache extends Cache {
 
   def terminateCache() {
     cache.foreach(_.terminateCache())
+    cache = None
   }
   def stats: Stats = {
     cache.map(_.stats).getOrElse(DisabledStats)

--- a/conf/docker/validations.conf
+++ b/conf/docker/validations.conf
@@ -1,4 +1,9 @@
 config.validations = [
+  collins.util.config.MultiCollinsConfig,
+  collins.util.config.Feature,
+  collins.guava.GuavaConfig,
+  collins.hazelcast.HazelcastConfig,
+  collins.cache.CacheConfig,
   collins.callbacks.CallbackConfig,
   collins.graphs.GraphConfig,
   collins.power.management.PowerManagementConfig,
@@ -8,16 +13,17 @@ config.validations = [
   collins.models.shared.IpAddressConfig,
   collins.models.shared.QueryLogConfig,
   collins.util.config.CryptoConfig,
-  collins.util.config.Feature,
   collins.util.config.IpmiConfig,
   collins.util.config.LshwConfig,
   collins.util.config.LldpConfig,
-  collins.util.config.MultiCollinsConfig,
   collins.util.config.NodeclassifierConfig,
   collins.util.power.PowerConfiguration,
   collins.util.security.AuthenticationProviderConfig,
   collins.util.security.FileAuthenticationProviderConfig,
   collins.util.security.LdapAuthenticationProviderConfig,
   collins.util.views.TagDecoratorConfig
-  collins.intake.IntakeConfig
+  collins.intake.IntakeConfig,
+  collins.graphs.GangliaGraphConfig,
+  collins.graphs.FibrGraphConfig,
+  collins.frames.ViewsConfig
 ]

--- a/test/collins/models/cache/CacheSpec.scala
+++ b/test/collins/models/cache/CacheSpec.scala
@@ -34,285 +34,296 @@ class CacheSpec extends mutable.Specification {
 
   args(sequential = true)
 
-  "Basic cache operations " should {
-    "return None when looking for an element not populated in cache " in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val assetFromCache = Cache.get[Asset](Asset.findByTagKey("notincache"))
-      assetFromCache mustEqual None
-    }
-  }
+  // run every test for both guava (in-memory) and hazelcast (distributed)
+  val applicationConfigs = List(Map("callbacks.enabled" -> false, "cache.type" -> "in-memory"),
+    Map("callbacks.enabled" -> false, "cache.type" -> "distributed", "hazelcast.enabled" -> true))
 
-  "Assets must be cached" in {
-
-    "during find for non existing asset cache should be populated with None" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val maybeAsset = Asset.findByTag("cacheasset1")
-      maybeAsset mustEqual None
-      val assetFromCache = Cache.get[Option[Asset]](Asset.findByTagKey("cacheasset1"))
-      assetFromCache mustEqual Some(None)
-    }
-
-    "after a create asset must be found in cache using tag" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val assetTag = "cacheasset1"
-      val maybeAsset = Asset.findByTag(assetTag)
-      maybeAsset mustEqual None
-      val assetFromCache = Cache.get[Option[Asset]](Asset.findByTagKey(assetTag))
-      assetFromCache mustEqual Some(None)
-
-      val asset = Asset.create(Asset(assetTag, Status.Incomplete.get, AssetType.ServerNode.get))
-      val afterCreateMaybeAsset = Asset.findByTag(assetTag)
-      afterCreateMaybeAsset mustEqual Some(asset)
-      val afterCreateAssetFromCache = Cache.get[Option[Asset]](Asset.findByTagKey(assetTag))
-      afterCreateAssetFromCache.get.get must matchAsset(asset)
-    }
-
-    "after a create asset must be found in cache using id" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val assetTag = "cacheasset1"
-      val maybeAsset = Asset.findByTag(assetTag)
-      maybeAsset mustEqual None
-      val assetFromCache = Cache.get[Option[Asset]](Asset.findByTagKey(assetTag))
-      assetFromCache mustEqual Some(None)
-
-      val asset = Asset.create(Asset(assetTag, Status.Incomplete.get, AssetType.ServerNode.get))
-      val afterCreateMaybeAsset = Asset.findById(asset.id)
-      afterCreateMaybeAsset mustEqual Some(asset)
-      val afterCreateAssetFromCache = Cache.get[Option[Asset]](Asset.findByIdKey(asset.id))
-      afterCreateAssetFromCache.get.get must matchAsset(asset)
-    }
-  }
-
-  "AssetMeta must be cached" in {
-    "find pre-populated asset meta" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val metas = AssetMeta.findAll()
-      val metasFromCache = Cache.get[List[AssetMeta]](AssetMeta.findByAllKey)
-      metasFromCache.get.zip(metas).foreach { case (s, t) => s must matchAssetMeta(t) }
-    }
-
-    "find pre-populated asset meta by name" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val meta = AssetMeta.findAll().head
-      val sameMeta = AssetMeta.findByName(meta.name)
-      sameMeta.get must matchAssetMeta(meta)
-
-      val metaFromCache = Cache.get[Option[AssetMeta]](AssetMeta.findByNameKey(meta.name))
-      metaFromCache.get.get must matchAssetMeta(meta)
-    }
-
-    "find pre-populated asset meta by id" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val meta = AssetMeta.findAll().head
-      val sameMeta = AssetMeta.findById(meta.id)
-      sameMeta.get must matchAssetMeta(meta)
-
-      val metaFromCache = Cache.get[Option[AssetMeta]](AssetMeta.findByIdKey(meta.id))
-      metaFromCache.get.get must matchAssetMeta(meta)
-    }
-
-    "find pre-populated by viewabled " in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val metas = AssetMeta.getViewable()
-      val metasFromCache = Cache.get[List[AssetMeta]](AssetMeta.findByViewableKey)
-      metasFromCache.get.zip(metas).foreach { case (s, t) => s must matchAssetMeta(t) }
-    }
-  }
-
-  "AssetType must be cached" in {
-    "find pre-populated asset types" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val types = AssetType.find
-      val typesFromCache = Cache.get[List[AssetType]](AssetType.findKey)
-      typesFromCache.get.zip(types).foreach { case (s, t) => s must matchAssetType(t) }
-    }
-
-    "find pre-populated asset type by name" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val assetType = AssetType.find.head
-      val sameType = AssetType.findByName(assetType.name)
-      sameType.get must matchAssetType(assetType)
-
-      val typeFromCache = Cache.get[Option[AssetType]](AssetType.findByNameKey(assetType.name))
-      typeFromCache.get.get must matchAssetType(assetType)
-    }
-
-    "find pre-populated asset type by id" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val assetType = AssetType.find.head
-      val sameType = AssetType.findById(assetType.id)
-      sameType.get must matchAssetType(assetType)
-
-      val typeFromCache = Cache.get[Option[AssetType]](AssetType.findByIdKey(assetType.id))
-      typeFromCache.get.get must matchAssetType(assetType)
-    }
-  }
-
-  "State must be cached" in {
-    "find pre-populated states" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val states = State.find
-      val statesFromCache = Cache.get[List[State]](State.findKey)
-      statesFromCache.get.zip(states).foreach {
-        case (s, t) =>
-          s must matchState(t)
+  applicationConfigs.foreach(c =>
+    "Basic cache operations " should {
+      "return None when looking for an element not populated in cache " in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val assetFromCache = Cache.get[Asset](Asset.findByTagKey("notincache"))
+        assetFromCache mustEqual None
       }
-    }
+    })
 
-    "find pre-populated state by name" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val state = State.find.head
-      val sameState = State.findByName(state.name)
-      sameState.get must matchState(state)
-
-      val stateFromCache = Cache.get[Option[State]](State.findByNameKey(state.name))
-      stateFromCache.get.get must matchState(state)
-    }
-
-    "find pre-populated state by id" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val state = State.find.head
-      val sameState = State.findById(state.id)
-      sameState.get must matchState(state)
-
-      val stateFromCache = Cache.get[Option[State]](State.findByIdKey(state.id))
-      stateFromCache.get.get must matchState(state)
-    }
-
-    "find pre-populated state by any status" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val states = State.findByAnyStatus()
-      states.size mustEqual 6
-      val statesFromCache = Cache.get[List[State]](State.findByAnyStatusKey)
-      statesFromCache.get.zip(states).foreach {
-        case (s, t) =>
-          s must matchState(t)
+  applicationConfigs.foreach(c =>
+    "Caching" should {
+      "during find for non existing asset cache should be populated with None" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val maybeAsset = Asset.findByTag("cacheasset1")
+        maybeAsset mustEqual None
+        val assetFromCache = Cache.get[Option[Asset]](Asset.findByTagKey("cacheasset1"))
+        assetFromCache mustEqual Some(None)
       }
-    }
 
-    "find pre-populated state by status key" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val status = Status.Maintenance.get
-      val state = State.findByStatus(status)
-      val stateFromCache = Cache.get[List[State]](State.findByStatusKey(status.id))
-      stateFromCache.get.zip(state).foreach { case (s, t) => s must matchState(t) }
-    }
-  }
+      "after a create asset must be found in cache using tag" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val assetTag = "cacheasset1"
+        val maybeAsset = Asset.findByTag(assetTag)
+        maybeAsset mustEqual None
+        val assetFromCache = Cache.get[Option[Asset]](Asset.findByTagKey(assetTag))
+        assetFromCache mustEqual Some(None)
 
-  "AssetMetaValues must be cached" in {
-    "find pre-populated meta value by asset and meta id" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val asset = Asset.findById(1).get
-      val assetMeta = AssetMeta.findById(1).get
-      val metaValues = AssetMetaValue.findByAssetAndMeta(asset, assetMeta, 10)
-      val metaValuesFromCache = Cache.get[List[MetaWrapper]](AssetMetaValue.findByAssetAndMetaKey(asset.id, assetMeta.id))
-      metaValuesFromCache.get.zip(metaValues).foreach {
-        case (s, t) => {
-          s._value must matchAssetMetaValue(t._value)
-          s._meta must matchAssetMeta(t._meta)
+        val asset = Asset.create(Asset(assetTag, Status.Incomplete.get, AssetType.ServerNode.get))
+        val afterCreateMaybeAsset = Asset.findByTag(assetTag)
+        afterCreateMaybeAsset mustEqual Some(asset)
+        val afterCreateAssetFromCache = Cache.get[Option[Asset]](Asset.findByTagKey(assetTag))
+        afterCreateAssetFromCache.get.get must matchAsset(asset)
+      }
+
+      "after a create asset must be found in cache using id" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val assetTag = "cacheasset1"
+        val maybeAsset = Asset.findByTag(assetTag)
+        maybeAsset mustEqual None
+        val assetFromCache = Cache.get[Option[Asset]](Asset.findByTagKey(assetTag))
+        assetFromCache mustEqual Some(None)
+
+        val asset = Asset.create(Asset(assetTag, Status.Incomplete.get, AssetType.ServerNode.get))
+        val afterCreateMaybeAsset = Asset.findById(asset.id)
+        afterCreateMaybeAsset mustEqual Some(asset)
+        val afterCreateAssetFromCache = Cache.get[Option[Asset]](Asset.findByIdKey(asset.id))
+        afterCreateAssetFromCache.get.get must matchAsset(asset)
+      }
+    })
+
+  applicationConfigs.foreach(c =>
+    "AssetMeta must be cached" in {
+      "find pre-populated asset meta" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val metas = AssetMeta.findAll()
+        val metasFromCache = Cache.get[List[AssetMeta]](AssetMeta.findByAllKey)
+        metasFromCache.get.zip(metas).foreach { case (s, t) => s must matchAssetMeta(t) }
+      }
+
+      "find pre-populated asset meta by name" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val meta = AssetMeta.findAll().head
+        val sameMeta = AssetMeta.findByName(meta.name)
+        sameMeta.get must matchAssetMeta(meta)
+
+        val metaFromCache = Cache.get[Option[AssetMeta]](AssetMeta.findByNameKey(meta.name))
+        metaFromCache.get.get must matchAssetMeta(meta)
+      }
+
+      "find pre-populated asset meta by id" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val meta = AssetMeta.findAll().head
+        val sameMeta = AssetMeta.findById(meta.id)
+        sameMeta.get must matchAssetMeta(meta)
+
+        val metaFromCache = Cache.get[Option[AssetMeta]](AssetMeta.findByIdKey(meta.id))
+        metaFromCache.get.get must matchAssetMeta(meta)
+      }
+
+      "find pre-populated by viewabled " in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val metas = AssetMeta.getViewable()
+        val metasFromCache = Cache.get[List[AssetMeta]](AssetMeta.findByViewableKey)
+        metasFromCache.get.zip(metas).foreach { case (s, t) => s must matchAssetMeta(t) }
+      }
+    })
+
+  applicationConfigs.foreach(c =>
+    "AssetType must be cached" in {
+      "find pre-populated asset types" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val types = AssetType.find
+        val typesFromCache = Cache.get[List[AssetType]](AssetType.findKey)
+        typesFromCache.get.zip(types).foreach { case (s, t) => s must matchAssetType(t) }
+      }
+
+      "find pre-populated asset type by name" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val assetType = AssetType.find.head
+        val sameType = AssetType.findByName(assetType.name)
+        sameType.get must matchAssetType(assetType)
+
+        val typeFromCache = Cache.get[Option[AssetType]](AssetType.findByNameKey(assetType.name))
+        typeFromCache.get.get must matchAssetType(assetType)
+      }
+
+      "find pre-populated asset type by id" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val assetType = AssetType.find.head
+        val sameType = AssetType.findById(assetType.id)
+        sameType.get must matchAssetType(assetType)
+
+        val typeFromCache = Cache.get[Option[AssetType]](AssetType.findByIdKey(assetType.id))
+        typeFromCache.get.get must matchAssetType(assetType)
+      }
+    })
+
+  applicationConfigs.foreach(c =>
+    "State must be cached" in {
+      "find pre-populated states" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val states = State.find
+        val statesFromCache = Cache.get[List[State]](State.findKey)
+        statesFromCache.get.zip(states).foreach {
+          case (s, t) =>
+            s must matchState(t)
         }
       }
 
-      // using method from Asset
-      val firstMetaValue = asset.getMetaAttribute(assetMeta.name).get
-      firstMetaValue._value must matchAssetMetaValue(metaValuesFromCache.get.head._value)
-      firstMetaValue._meta must matchAssetMeta(metaValuesFromCache.get.head._meta)
-      firstMetaValue._value must matchAssetMetaValue(metaValues.head._value)
-      firstMetaValue._meta must matchAssetMeta(metaValues.head._meta)
-    }
+      "find pre-populated state by name" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val state = State.find.head
+        val sameState = State.findByName(state.name)
+        sameState.get must matchState(state)
 
-    "find pre-populated meta value by asset" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val asset = Asset.findById(1).get
-      val metaValues = AssetMetaValue.findByAsset(asset)
-      val metaValuesFromCache = Cache.get[List[MetaWrapper]](AssetMetaValue.findByAssetKey(asset.id))
-      metaValuesFromCache.get.zip(metaValues).foreach {
-        case (s, t) => {
-          s._value must matchAssetMetaValue(t._value)
-          s._meta must matchAssetMeta(t._meta)
+        val stateFromCache = Cache.get[Option[State]](State.findByNameKey(state.name))
+        stateFromCache.get.get must matchState(state)
+      }
+
+      "find pre-populated state by id" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val state = State.find.head
+        val sameState = State.findById(state.id)
+        sameState.get must matchState(state)
+
+        val stateFromCache = Cache.get[Option[State]](State.findByIdKey(state.id))
+        stateFromCache.get.get must matchState(state)
+      }
+
+      "find pre-populated state by any status" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val states = State.findByAnyStatus()
+        states.size mustEqual 6
+        val statesFromCache = Cache.get[List[State]](State.findByAnyStatusKey)
+        statesFromCache.get.zip(states).foreach {
+          case (s, t) =>
+            s must matchState(t)
         }
       }
-    }
 
-    "find pre-populated meta value by meta" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val assetMeta = AssetMeta.findById(1).get
-      val metaValues = AssetMetaValue.findByMeta(assetMeta)
-      val metaValuesFromCache = Cache.get[List[String]](AssetMetaValue.findByMetaKey(assetMeta.id))
-      metaValuesFromCache.get.zip(metaValues).foreach { case (s, t) => s mustEqual t }
-    }
-  }
-
-  "IpmiInfo must be cached" in {
-
-    "find pre-populated ipmi info by asset" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val asset = Asset.findById(1).get
-      val ipmiInfo = IpmiInfo.findByAsset(asset).get
-      val ipmiInfoFromCache = Cache.get[Option[IpmiInfo]](IpmiInfo.findByAssetKey(asset.id))
-      ipmiInfoFromCache.get.get must matchIpmiInfo(ipmiInfo)
-    }
-
-    "find pre-populated all ipmi info by asset" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val asset = Asset.findById(1).get
-      val ipmiInfo = IpmiInfo.findAllByAsset(asset)
-      val ipmiInfoFromCache = Cache.get[List[IpmiInfo]](IpmiInfo.findAllByAssetKey(asset.id))
-      ipmiInfoFromCache.get.zip(ipmiInfo).foreach {
-        case (s, t) =>
-          s must matchIpmiInfo(t)
+      "find pre-populated state by status key" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val status = Status.Maintenance.get
+        val state = State.findByStatus(status)
+        val stateFromCache = Cache.get[List[State]](State.findByStatusKey(status.id))
+        stateFromCache.get.zip(state).foreach { case (s, t) => s must matchState(t) }
       }
-    }
+    })
 
-    "find pre-populated ipmi info by id" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val ipmiInfo = IpmiInfo.get(IpmiInfo(1, "test-user", "", 167772161L, 167772162L, 4294959104L, 1))
-      val ipmiInfoFromCache = Cache.get[IpmiInfo](IpmiInfo.findByIdKey(ipmiInfo.id))
-      ipmiInfoFromCache.get must matchIpmiInfo(ipmiInfo)
-    }
-  }
+  applicationConfigs.foreach(c =>
+    "AssetMetaValues must be cached" in {
+      "find pre-populated meta value by asset and meta id" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val asset = Asset.findById(1).get
+        val assetMeta = AssetMeta.findById(1).get
+        val metaValues = AssetMetaValue.findByAssetAndMeta(asset, assetMeta, 10)
+        val metaValuesFromCache = Cache.get[List[MetaWrapper]](AssetMetaValue.findByAssetAndMetaKey(asset.id, assetMeta.id))
+        metaValuesFromCache.get.zip(metaValues).foreach {
+          case (s, t) => {
+            s._value must matchAssetMetaValue(t._value)
+            s._meta must matchAssetMeta(t._meta)
+          }
+        }
 
-  "IpAddress must be cached" in {
-    "find ip address by asset" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val asset = Asset.findById(1).get
-      IpAddresses.create(IpAddresses(asset.id, IpAddress.toLong("10.0.0.1"),
-        IpAddress.toLong("10.0.0.2"), IpAddress.toLong("255.255.224.0"), "fortesting"))
-      val address = IpAddresses.findByAsset(asset).get
-      val addressFromCache = Cache.get[Option[IpAddresses]](IpAddresses.findByAssetKey(asset.id))
-      addressFromCache.get.get must matchAddress(address)
-    }
+        // using method from Asset
+        val firstMetaValue = asset.getMetaAttribute(assetMeta.name).get
+        firstMetaValue._value must matchAssetMetaValue(metaValuesFromCache.get.head._value)
+        firstMetaValue._meta must matchAssetMeta(metaValuesFromCache.get.head._meta)
+        firstMetaValue._value must matchAssetMetaValue(metaValues.head._value)
+        firstMetaValue._meta must matchAssetMeta(metaValues.head._meta)
+      }
 
-    "find all ip address by asset" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val asset = Asset.findById(1).get
-      IpAddresses.create(IpAddresses(asset.id, IpAddress.toLong("10.0.0.1"),
-        IpAddress.toLong("10.0.0.2"), IpAddress.toLong("255.255.224.0"), "fortesting"))
-      val addresses = IpAddresses.findAllByAsset(asset)
-      val addressesFromCache = Cache.get[List[IpAddresses]](IpAddresses.findAllByAssetKey(asset.id))
-      addressesFromCache.get.zip(addresses).foreach { case (s, t) => s must matchAddress(t) }
-    }
+      "find pre-populated meta value by asset" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val asset = Asset.findById(1).get
+        val metaValues = AssetMetaValue.findByAsset(asset)
+        val metaValuesFromCache = Cache.get[List[MetaWrapper]](AssetMetaValue.findByAssetKey(asset.id))
+        metaValuesFromCache.get.zip(metaValues).foreach {
+          case (s, t) => {
+            s._value must matchAssetMetaValue(t._value)
+            s._meta must matchAssetMeta(t._meta)
+          }
+        }
+      }
 
-    "find ip address by id" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val asset = Asset.findById(1).get
-      val address = IpAddresses.get(IpAddresses.create(new IpAddresses(asset.id, IpAddress.toLong("10.0.0.1"),
-        IpAddress.toLong("10.0.0.2"), IpAddress.toLong("255.255.224.0"), "fortesting")))
-      val addressFromCache = Cache.get[IpAddresses](IpAddresses.findByIdKey(address.id))
-      addressFromCache.get must matchAddress(address)
-    }
+      "find pre-populated meta value by meta" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val assetMeta = AssetMeta.findById(1).get
+        val metaValues = AssetMetaValue.findByMeta(assetMeta)
+        val metaValuesFromCache = Cache.get[List[String]](AssetMetaValue.findByMetaKey(assetMeta.id))
+        metaValuesFromCache.get.zip(metaValues).foreach { case (s, t) => s mustEqual t }
+      }
+    })
 
-    "find pools in use" in new WithApplication(FakeApplication(
-      additionalConfiguration = Map("callbacks.enabled" -> false))) {
-      val asset = Asset.findById(1).get
-      IpAddresses.create(new IpAddresses(asset.id, IpAddress.toLong("10.0.0.1"),
-        IpAddress.toLong("10.0.0.2"), IpAddress.toLong("255.255.224.0"), "fortesting"))
-      val pools = IpAddresses.getPoolsInUse()
-      pools mustEqual Set("fortesting")
-      val poolsFromCache = Cache.get[Option[IpAddresses]](IpAddresses.findPoolsInUseKey)
-      poolsFromCache mustEqual Some(pools)
-    }
-  }
+  applicationConfigs.foreach(c =>
+    "IpmiInfo must be cached" in {
+
+      "find pre-populated ipmi info by asset" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val asset = Asset.findById(1).get
+        val ipmiInfo = IpmiInfo.findByAsset(asset).get
+        val ipmiInfoFromCache = Cache.get[Option[IpmiInfo]](IpmiInfo.findByAssetKey(asset.id))
+        ipmiInfoFromCache.get.get must matchIpmiInfo(ipmiInfo)
+      }
+
+      "find pre-populated all ipmi info by asset" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val asset = Asset.findById(1).get
+        val ipmiInfo = IpmiInfo.findAllByAsset(asset)
+        val ipmiInfoFromCache = Cache.get[List[IpmiInfo]](IpmiInfo.findAllByAssetKey(asset.id))
+        ipmiInfoFromCache.get.zip(ipmiInfo).foreach {
+          case (s, t) =>
+            s must matchIpmiInfo(t)
+        }
+      }
+
+      "find pre-populated ipmi info by id" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val ipmiInfo = IpmiInfo.get(IpmiInfo(1, "test-user", "", 167772161L, 167772162L, 4294959104L, 1))
+        val ipmiInfoFromCache = Cache.get[IpmiInfo](IpmiInfo.findByIdKey(ipmiInfo.id))
+        ipmiInfoFromCache.get must matchIpmiInfo(ipmiInfo)
+      }
+    })
+
+  applicationConfigs.foreach(c =>
+    "IpAddress must be cached" in {
+      "find ip address by asset" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val asset = Asset.findById(1).get
+        IpAddresses.create(IpAddresses(asset.id, IpAddress.toLong("10.0.0.1"),
+          IpAddress.toLong("10.0.0.2"), IpAddress.toLong("255.255.224.0"), "fortesting"))
+        val address = IpAddresses.findByAsset(asset).get
+        val addressFromCache = Cache.get[Option[IpAddresses]](IpAddresses.findByAssetKey(asset.id))
+        addressFromCache.get.get must matchAddress(address)
+      }
+
+      "find all ip address by asset" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val asset = Asset.findById(1).get
+        IpAddresses.create(IpAddresses(asset.id, IpAddress.toLong("10.0.0.1"),
+          IpAddress.toLong("10.0.0.2"), IpAddress.toLong("255.255.224.0"), "fortesting"))
+        val addresses = IpAddresses.findAllByAsset(asset)
+        val addressesFromCache = Cache.get[List[IpAddresses]](IpAddresses.findAllByAssetKey(asset.id))
+        addressesFromCache.get.zip(addresses).foreach { case (s, t) => s must matchAddress(t) }
+      }
+
+      "find ip address by id" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val asset = Asset.findById(1).get
+        val address = IpAddresses.get(IpAddresses.create(new IpAddresses(asset.id, IpAddress.toLong("10.0.0.1"),
+          IpAddress.toLong("10.0.0.2"), IpAddress.toLong("255.255.224.0"), "fortesting")))
+        val addressFromCache = Cache.get[IpAddresses](IpAddresses.findByIdKey(address.id))
+        addressFromCache.get must matchAddress(address)
+      }
+
+      "find pools in use" in new WithApplication(FakeApplication(
+        additionalConfiguration = c)) {
+        val asset = Asset.findById(1).get
+        IpAddresses.create(new IpAddresses(asset.id, IpAddress.toLong("10.0.0.1"),
+          IpAddress.toLong("10.0.0.2"), IpAddress.toLong("255.255.224.0"), "fortesting"))
+        val pools = IpAddresses.getPoolsInUse()
+        pools mustEqual Set("fortesting")
+        val poolsFromCache = Cache.get[Option[IpAddresses]](IpAddresses.findPoolsInUseKey)
+        poolsFromCache mustEqual Some(pools)
+      }
+    })
 }
 
 case class matchAsset(t: Asset) extends Matcher[Asset] {


### PR DESCRIPTION
Running the cache spec for both In-memory (Guava) and Distributed (Hazelcast) specifications.

While writing the developer documentation on the wiki, I ran into an issue with configuration validation for the container / dockerbuild. Validation configs weren't update under `conf/docker`.

One thing led to another and we now run the `CacheSpec` for both in-memory and distributed modes.

@roymarantz @byxorna @defect @Primer42 