### PR TITLE
Implement a firehose for events

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -13,6 +13,7 @@ import play.api.mvc.Results
 import collins.callbacks.Callback
 import collins.controllers.ApiResponse
 import collins.db.DB
+import collins.firehose.Firehose
 import collins.hazelcast.HazelcastHelper
 import collins.logging.LoggingHelper
 import collins.metrics.MetricsReporter
@@ -46,6 +47,7 @@ object Global extends GlobalSettings with AuthenticationAccessor with CryptoAcce
     setCryptoKey(CryptoConfig.key)
     LoggingHelper.setupLogging(app)
     Callback.setupCallbacks()
+    Firehose.setupFirehose()
     SolrHelper.setupSolr()
     MetricsReporter.setupMetrics()
   }

--- a/app/collins/controllers/Api.scala
+++ b/app/collins/controllers/Api.scala
@@ -2,6 +2,8 @@ package collins.controllers
 
 import java.util.Date
 
+import play.api.libs.EventSource
+import play.api.libs.EventSource.EventNameExtractor
 import play.api.libs.json.JsArray
 import play.api.libs.json.JsBoolean
 import play.api.libs.json.JsNumber
@@ -16,6 +18,8 @@ import play.api.mvc.Result
 import play.api.mvc.Results
 
 import collins.controllers.actors.TestProcessor
+import collins.firehose.Firehose
+import collins.firehose.FirehoseConfig
 import collins.models.Asset
 import collins.util.BashOutput
 import collins.util.HtmlOutput
@@ -25,13 +29,12 @@ import collins.util.TextOutput
 import collins.util.concurrent.BackgroundProcessor
 import collins.util.views.Formatter
 
-private[controllers] case class ResponseData(status: Results.Status, data: JsValue, headers: Seq[(String,String)] = Nil, attachment: Option[AnyRef] = None) {
+private[controllers] case class ResponseData(status: Results.Status, data: JsValue, headers: Seq[(String, String)] = Nil, attachment: Option[AnyRef] = None) {
   def asResult(implicit req: Request[AnyContent]): Result =
     ApiResponse.formatResponseData(this)(req)
 }
 
-trait Api extends ApiResponse with AssetApi with AssetTypeApi with AssetManagementApi with AssetWebApi with AssetLogApi with IpmiApi with TagApi with
-IpAddressApi with AssetStateApi with AdminApi {
+trait Api extends ApiResponse with AssetApi with AssetTypeApi with AssetManagementApi with AssetWebApi with AssetLogApi with IpmiApi with TagApi with IpAddressApi with AssetStateApi with AdminApi {
   this: SecureController =>
 
   lazy protected implicit val securitySpec = Permissions.LoggedIn
@@ -51,52 +54,71 @@ IpAddressApi with AssetStateApi with AdminApi {
     }
   }
 
+  def firehose = Action { implicit request =>
+    if (FirehoseConfig.enabled) {
+      authenticate(request) match {
+        case None =>
+          logger.debug("Authentication required and NOT successful for streams")
+          Results.Forbidden
+        case Some(user) => authorize(user, Permissions.Firehose.Stream) match {
+          case false =>
+            logger.debug("Authorization required and NOT successful for streams")
+            Results.Forbidden
+          case true =>
+            // specify an name extractor, all events are dispatched with a name
+            implicit val eventNameExtractor = EventNameExtractor[JsValue](_.\("name").asOpt[String])
+            Results.Ok.feed(Firehose.out &> EventSource()).as("text/event-stream")
+        }
+      }
+    } else {
+      Results.ServiceUnavailable
+    }
+  }
+
   def ping = Action { implicit req =>
     formatResponseData(ResponseData(Results.Ok, JsObject(Seq(
       "Data" -> JsObject(Seq(
         "Timestamp" -> JsString(Formatter.dateFormat(new Date())),
         "TestObj" -> JsObject(Seq(
           "TestString" -> JsString("test"),
-          "TestList" -> JsArray(List(JsNumber(1), JsNumber(2)))
-        )),
+          "TestList" -> JsArray(List(JsNumber(1), JsNumber(2))))),
         "TestList" -> JsArray(List(
           JsObject(Seq("id" -> JsNumber(123), "name" -> JsString("foo123"), "key-with-dash" -> JsString("val-with-dash"))),
           JsObject(Seq("id" -> JsNumber(124), "name" -> JsString("foo124"))),
-          JsObject(Seq("id" -> JsNumber(124), "name" -> JsString("foo124")))
-        ))
-      )),
-      "Status" -> JsString("Ok")
-    ))))
+          JsObject(Seq("id" -> JsNumber(124), "name" -> JsString("foo124"))))))),
+      "Status" -> JsString("Ok")))))
   }
 
   def asyncPing(sleepMs: Long) = Action.async { implicit req =>
-    BackgroundProcessor.send(TestProcessor(sleepMs)) { r => r match {
-      case Left(_) => formatResponseData(Api.statusResponse(false))
-      case Right(res) => formatResponseData(Api.statusResponse(res))
-    }}
+    BackgroundProcessor.send(TestProcessor(sleepMs)) { r =>
+      r match {
+        case Left(_)    => formatResponseData(Api.statusResponse(false))
+        case Right(res) => formatResponseData(Api.statusResponse(res))
+      }
+    }
   }
 
   def errorPing(id: Int) = Action { implicit req =>
-    req.queryString.map { case(k,v) =>
-      k match {
-        case "foo" =>
-          formatResponseData(ResponseData(Results.Ok, JsObject(Seq("Result" -> JsBoolean(true)))))
-      }
+    req.queryString.map {
+      case (k, v) =>
+        k match {
+          case "foo" =>
+            formatResponseData(ResponseData(Results.Ok, JsObject(Seq("Result" -> JsBoolean(true)))))
+        }
     }.head
   }
 }
 
 object Api {
-  def withAssetFromTag[T](tag: String)(f: Asset => Either[ResponseData,T]): Either[ResponseData,T] = {
+  def withAssetFromTag[T](tag: String)(f: Asset => Either[ResponseData, T]): Either[ResponseData, T] = {
     Asset.isValidTag(tag) match {
       case false => Left(getErrorMessage("Invalid tag specified"))
       case true => Asset.findByTag(tag) match {
         case Some(asset) => f(asset)
-        case None => Left(getErrorMessage("Could not find specified asset", Results.NotFound))
+        case None        => Left(getErrorMessage("Could not find specified asset", Results.NotFound))
       }
     }
   }
-
 
   def statusResponse(status: Boolean, code: Results.Status = Results.Ok) =
     ResponseData(code, JsObject(Seq("SUCCESS" -> JsBoolean(status))))

--- a/app/collins/controllers/Permissions.scala
+++ b/app/collins/controllers/Permissions.scala
@@ -121,4 +121,8 @@ object Permissions {
     def GetTagValues = spec("getTagValues", AdminSpec)
   }
 
+  object Firehose extends PermSpec("controllers.Firehose") {
+    def Spec = spec(LoggedIn)
+    def Stream = spec("stream", Spec)
+  }
 }

--- a/app/collins/firehose/Category.scala
+++ b/app/collins/firehose/Category.scala
@@ -1,0 +1,9 @@
+package collins.firehose
+
+sealed abstract class Category
+
+case object Category {
+  case object Asset extends Category
+  case object Meta extends Category
+  case object IpAddress extends Category
+}

--- a/app/collins/firehose/Firehose.scala
+++ b/app/collins/firehose/Firehose.scala
@@ -1,0 +1,51 @@
+package collins.firehose
+
+import play.api.Logger
+import play.api.Play.current
+import play.api.libs.concurrent.Akka
+import play.api.libs.iteratee.Concurrent
+import play.api.libs.json.JsValue
+
+import com.hazelcast.core.Message
+import com.hazelcast.core.MessageListener
+
+import collins.callbacks.Callback
+import collins.hazelcast.HazelcastHelper
+
+import akka.actor.Props
+import akka.routing.FromConfig
+
+object Firehose {
+  private[this] val logger = Logger(getClass)
+
+  /** Central hub for distributing firehose events  */
+  val (out, channel) = Concurrent.broadcast[JsValue]
+
+  def setupFirehose() {
+
+    if (FirehoseConfig.enabled) {
+      logger.info("Installing callbacks for firehose")
+      val processor = Akka.system.actorOf(Props[FirehoseProcessor].withRouter(FromConfig()), name = "firehose_processor")
+
+      val callback = FirehoseCallbackHandler(processor)
+      Callback.on("asset_update", callback)
+      Callback.on("asset_create", callback)
+      Callback.on("asset_delete", callback)
+      Callback.on("asset_purge", callback)
+      Callback.on("ipAddresses_create", callback)
+      Callback.on("ipAddresses_update", callback)
+      Callback.on("ipAddresses_delete", callback)
+    }
+
+    // instantiate a listener for topic events
+    val topic = HazelcastHelper.getTopic()
+    val ml = new MessageListener[JsValue]() {
+      def onMessage(message: Message[JsValue]) {
+        val mo = message.getMessageObject
+        channel.push(mo)
+      }
+    }
+
+    topic.map(_.addMessageListener(ml))
+  }
+}

--- a/app/collins/firehose/FirehoseCallbackHandler.scala
+++ b/app/collins/firehose/FirehoseCallbackHandler.scala
@@ -1,0 +1,36 @@
+package collins.firehose
+
+import java.beans.PropertyChangeEvent
+
+import play.api.Logger
+
+import collins.callbacks.CallbackDatumHolder
+import collins.callbacks.StringDatum
+import collins.callbacks.CallbackActionHandler
+import collins.models.Asset
+import collins.models.AssetMetaValue
+import collins.models.IpAddresses
+import collins.models.asset.AllAttributes
+
+import akka.actor.ActorRef
+import akka.actor.actorRef2Scala
+
+case class FirehoseCallbackHandler(writer: ActorRef) extends CallbackActionHandler {
+  private[this] val logger = Logger(getClass)
+
+  override def apply(pce: PropertyChangeEvent) = processValue(pce, getValue(pce))
+
+  protected def processValue(pce: PropertyChangeEvent, v: CallbackDatumHolder) = v match {
+    case CallbackDatumHolder(Some(a: Asset))          => writer ! new Event(pce.getPropertyName, Category.Asset, AllAttributes.get(a))
+    case CallbackDatumHolder(Some(v: AssetMetaValue)) => writer ! new Event(pce.getPropertyName, Category.Meta, AllAttributes.get(v.asset))
+    case CallbackDatumHolder(Some(i: IpAddresses))    => writer ! new Event(pce.getPropertyName, Category.IpAddress, AllAttributes.get(i.getAsset))
+    case CallbackDatumHolder(Some(StringDatum(s))) =>
+      logger.warn("Got purge event for %s".format(s))
+    case CallbackDatumHolder(Some(x)) =>
+      logger.info(f"""Unexpected entity to firehose callback handler, ignoring entity event call back for ${x.toString}%s.
+         Supported entities are "Asset", "AssetMetaValue", "IpAddresses"""")
+    case o =>
+      logger.error(f"""Unknown type in firehose callback handler ${maybeNullString(o)}%s
+        Supported entities are "Asset", "AssetMetaValue", "IpAddresses"""")
+  }
+}

--- a/app/collins/firehose/FirehoseConfig.scala
+++ b/app/collins/firehose/FirehoseConfig.scala
@@ -1,0 +1,29 @@
+package collins.firehose
+
+import collins.hazelcast.HazelcastConfig
+import collins.callbacks.CallbackConfig
+import collins.util.MessageHelper
+import collins.util.config.Configurable
+
+object FirehoseConfig extends Configurable {
+
+  override val namespace = "firehose"
+  override val referenceConfigFilename = "firehose_reference.conf"
+
+  def enabled = getBoolean("enabled", false)
+  def registerTimeoutMs = getMilliseconds("registerTimeout").getOrElse(2000L)
+
+  object Messages extends MessageHelper("firehose") {
+    def callbacksNotEnabled =
+      messageWithDefault("callbacksNotEnabled", "Firehose requires callbacks, ensure callbacks are enabled.")
+    def hazelcastNotEnabled =
+      messageWithDefault("hazelcastNotEnabled", "Firehose requires hazelcast, ensure hazelcast is enabled.")
+  }
+
+  override protected def validateConfig() {
+    if (enabled) {
+      require(CallbackConfig.enabled, Messages.callbacksNotEnabled)
+      require(HazelcastConfig.enabled, Messages.hazelcastNotEnabled)
+    }
+  }
+}

--- a/app/collins/firehose/FirehoseProcessor.scala
+++ b/app/collins/firehose/FirehoseProcessor.scala
@@ -1,0 +1,34 @@
+package collins.firehose
+
+import play.api.Logger
+import play.api.libs.json.JsObject
+import play.api.libs.json.JsString
+
+import collins.hazelcast.HazelcastHelper
+import collins.models.asset.AllAttributes
+
+import akka.actor.Actor
+
+case class Event(name: String, tag: String, category: Category, asset: Option[AllAttributes]) {
+  def this(name: String, category: Category, asset: AllAttributes) {
+    this(name, asset.asset.tag, category, Some(asset))
+  }
+}
+
+class FirehoseProcessor extends Actor {
+  private[this] val logger = Logger(getClass)
+
+  def receive = {
+    case Event(name, tag, category, asset) =>
+      logger.trace("Received a message of category %s for asset with tag %s on name %s".format(category, tag, name))
+
+      val event = JsObject(Seq(
+        "name" -> JsString(name),
+        "tag" -> JsString(tag),
+        "category" -> JsString(category.toString),
+        "data" -> asset.map(_.toJsValue()).getOrElse(JsObject(Seq()))))
+
+      val topic = HazelcastHelper.getTopic()
+      topic.map(_.publish(event))
+  }
+}

--- a/app/collins/hazelcast/HazelcastHelper.scala
+++ b/app/collins/hazelcast/HazelcastHelper.scala
@@ -1,6 +1,7 @@
 package collins.hazelcast
 
 import play.api.Logger
+import play.api.libs.json.JsValue
 
 import com.hazelcast.config.FileSystemXmlConfig
 import com.hazelcast.core.Hazelcast
@@ -29,6 +30,10 @@ object HazelcastHelper {
 
   def getCache() = {
     instance.map(_.getMap[String, AnyRef]("cache"))
+  }
+
+  def getTopic() = {
+    instance.map(_.getReliableTopic[JsValue]("firehose"))
   }
 
   def terminateHazelcast() {

--- a/conf/dev_base.conf
+++ b/conf/dev_base.conf
@@ -335,6 +335,12 @@ akka {
         router = round-robin
         nr-of-instances = 1
       }
+
+      /firehose_processor = {
+        dispatcher = default-dispatcher
+        router = round-robin
+        nr-of-instances = 1
+      }
     }
   }
 }

--- a/conf/permissions.yaml
+++ b/conf/permissions.yaml
@@ -117,3 +117,9 @@ permissions:
     - "g=sre"
     - "u=admins"
     - "u=tools"
+  controllers.Firehose.stream:
+    - "g=infra"
+    - "g=ops"
+    - "g=sre"
+    - "u=admins"
+    - "u=tools"

--- a/conf/reference/firehose_reference.conf
+++ b/conf/reference/firehose_reference.conf
@@ -1,0 +1,5 @@
+firehose {
+  enabled = false
+  # timeout when a client tries to register for firehose events
+  registerTimeout = 2000
+}

--- a/conf/routes
+++ b/conf/routes
@@ -42,11 +42,12 @@ GET     /logout                     collins.controllers.Application.logout
 # API
 
 # Generic Functionality
-GET     /api/timestamp                       collins.app.Api.timestamp
+GET     /api/timestamp              collins.app.Api.timestamp
+GET     /api/firehose               collins.app.Api.firehose
 
 # Admin API
-GET     /api/admin/solr                          collins.app.Api.repopulateSolr(waitForCompletion: String ?= "true")
-GET     /api/admin/solr/asset/:tag               collins.app.Api.reindexAsset(tag: String)
+GET     /api/admin/solr             collins.app.Api.repopulateSolr(waitForCompletion: String ?= "true")
+GET     /api/admin/solr/asset/:tag  collins.app.Api.reindexAsset(tag: String)
 
 # IP Address API
 GET     /api/address/pools                   collins.app.Api.getAddressPools(all: String ?= "true")

--- a/conf/validations.conf
+++ b/conf/validations.conf
@@ -5,6 +5,7 @@ config.validations = [
   collins.hazelcast.HazelcastConfig,
   collins.cache.CacheConfig,
   collins.callbacks.CallbackConfig,
+  collins.firehose.FirehoseConfig,
   collins.graphs.GraphConfig,
   collins.power.management.PowerManagementConfig,
   collins.provisioning.ProvisionerConfig,


### PR DESCRIPTION
Summary:
A firehose implementation using server sent events. Relies
on callback mechanism to implement the firehose. All events
from the firehose return as part of data the asset that is
associated with the event.

All events for assets, asset meta values and ip addresses
are supported.

Every event includes an event name. Supports clustered
installations by making use of hazelcast reliable topic.

The firehose callback processing actor writes events to the
hazelcast reliable topic. We rely on hazelcast to distribute
the event to the cluster.

A single instance of collins installs a listener for the topic,
receives the message and writes it out to all clients of
the firehose.

Prerequisites for using the firehose:

Hazelcast MUST be enabled, does NOT need to be used for cache. This
deployment is applicable when running in stand alone more.

Callbacks MUST be enabled. Callbacks are also required for
search (Solr).

Configuration:

Hazelcast configuration is captured in conf/hazelcast.xml. The
topic can documentation is at [1].

[1] http://docs.hazelcast.org/docs/latest-dev/manual/html/reliabletopicconfiguration.html#reliable-topic-configuration
