### PR TITLE
--pool is a required argument to collins-shell ip_address create

### DIFF
--- a/support/ruby/collins-shell/lib/collins_shell/ip_address.rb
+++ b/support/ruby/collins-shell/lib/collins_shell/ip_address.rb
@@ -101,7 +101,7 @@ module CollinsShell
     method_option :address, :required => true, :type => :string, :desc => 'IP address'
     method_option :gateway, :required => true, :type => :string, :desc => 'IP gateway'
     method_option :netmask, :required => true, :type => :string, :desc => 'IP netmask'
-    method_option :pool, :type => :string, :desc => 'Name of pool'
+    method_option :pool, :required => true, :type => :string, :desc => 'Name of pool'
     def create
       call_collins get_collins_client, "create address" do |client|
         address = client.ipaddress_update! options.tag, nil,


### PR DESCRIPTION
Updating this adds --pool=POOL to the help text for collins-shell ip_address create which means it is possible to get an ip_address create right on the first try.  Also accurate help text is useful :)