### PR TITLE
[ipmi] allow templating of asset tag in config

### DIFF
--- a/app/collins/power/management/PowerManagement.scala
+++ b/app/collins/power/management/PowerManagement.scala
@@ -26,6 +26,7 @@ import collins.util.concurrent.BackgroundProcessor
 case class IpmiPowerCommand(
   override val ipmiCommand: String,
   override val ipmiInfo: IpmiInfo,
+  override val assetTag: String,
   override val interval: Duration = 60.seconds,
   verify: Boolean = false,
   userTimeout: Option[FiniteDuration] = None)
@@ -53,7 +54,7 @@ object IpmiPowerCommand {
     case None => ipmiErr(asset)
     case Some(ipmi) =>
       val cmd = commandFor(action)
-      new IpmiPowerCommand(cmd, ipmi)
+      new IpmiPowerCommand(cmd, ipmi, asset.tag)
   }
 }
 

--- a/app/collins/util/IpmiCommand.scala
+++ b/app/collins/util/IpmiCommand.scala
@@ -13,6 +13,7 @@ import collins.util.concurrent.BackgroundProcess
 import collins.util.config.AppConfig
 
 abstract class IpmiCommand extends BackgroundProcess[Option[CommandResult]] {
+  val assetTag: String
   val interval: Duration
   var debug: Boolean = false
 
@@ -65,5 +66,6 @@ abstract class IpmiCommand extends BackgroundProcess[Option[CommandResult]] {
       .replace("<username>", username)
       .replace("<password>", password)
       .replace("<interval>", interval.toSeconds.toString)
+      .replace("<tag>", assetTag)
   }
 }


### PR DESCRIPTION
It can be useful to have access to an asset's tag in the configuration file for IPMI commands. This enables the asset tag to be accessed as `<tag>` similar to other substitutions. A separate PR will update the docs.