### PR TITLE
[docs] include new tag substitution in ipmi docs

### DIFF
--- a/_includes/configuration/powermgmt.html
+++ b/_includes/configuration/powermgmt.html
@@ -125,6 +125,10 @@ them or powering them off, you will want to provide a power management configura
   </thead>
   <tbody>
     <tr>
+      <td class="inlinecode">&lt;tag&gt;</td>
+      <td>The tag of the asset being operated on</td>
+    </tr>
+    <tr>
       <td class="inlinecode">&lt;username&gt;</td>
       <td>The IPMI username associated with the asset</td>
     </tr>


### PR DESCRIPTION
We recently added functionality to access an assets tag in IPMI configuration. This updates the docs to reflect that.