### PR TITLE
Gabe optional ipmi power restrictions

### DIFF
--- a/app/collins/power/management/PowerManagement.scala
+++ b/app/collins/power/management/PowerManagement.scala
@@ -20,7 +20,7 @@ import collins.power.PowerState
 import collins.power.RebootHard
 import collins.power.RebootSoft
 import collins.power.Verify
-import collins.util.IpmiCommand
+import collins.util.PowerCommand
 import collins.util.concurrent.BackgroundProcessor
 
 case class IpmiPowerCommand(
@@ -30,7 +30,7 @@ case class IpmiPowerCommand(
   override val interval: Duration = 60.seconds,
   verify: Boolean = false,
   userTimeout: Option[FiniteDuration] = None)
-extends IpmiCommand {
+extends PowerCommand {
   override val timeout = userTimeout.getOrElse(Duration(PowerManagementConfig.timeoutMs, TimeUnit.MILLISECONDS))
 }
 

--- a/app/collins/power/management/PowerManagement.scala
+++ b/app/collins/power/management/PowerManagement.scala
@@ -25,7 +25,7 @@ import collins.util.concurrent.BackgroundProcessor
 
 case class IpmiPowerCommand(
   override val ipmiCommand: String,
-  override val ipmiInfo: IpmiInfo,
+  override val ipmiInfo: Option[IpmiInfo],
   override val assetTag: String,
   override val interval: Duration = 60.seconds,
   verify: Boolean = false,
@@ -47,14 +47,17 @@ object IpmiPowerCommand {
     case Identify => PMC.identifyCommand
   }
 
-  private def ipmiErr(a: Asset) =
-    throw new IllegalStateException("Could not find IPMI info for asset %s".format(a.tag))
-
   def fromPowerAction(asset: Asset, action: PowerAction) = IpmiInfo.findByAsset(asset) match {
-    case None => ipmiErr(asset)
+    case None =>
+      if (PMC.allowAssetsWithoutIpmi) {
+        val cmd = commandFor(action)
+        new IpmiPowerCommand(cmd, None, asset.tag)
+      } else {
+        throw new IllegalStateException("No IPMI configuration for asset %s".format(asset.tag))
+      }
     case Some(ipmi) =>
       val cmd = commandFor(action)
-      new IpmiPowerCommand(cmd, ipmi, asset.tag)
+      new IpmiPowerCommand(cmd, Some(ipmi), asset.tag)
   }
 }
 

--- a/app/collins/power/management/PowerManagementConfig.scala
+++ b/app/collins/power/management/PowerManagementConfig.scala
@@ -51,6 +51,10 @@ object PowerManagementConfig extends Configurable {
 
   def enabled = getBoolean("enabled", false)
   def timeoutMs = getMilliseconds("timeout").getOrElse(10000L)
+  // allowAssetsWithoutIpmi (default: false) - If false, only allow power management of assets
+  // with valid IPMI details. If true, restricts templating of the IPMI commands to
+  // only <tag>.
+  def allowAssetsWithoutIpmi = getBoolean("allowAssetsWithoutIpmi").getOrElse(true)
 
   def powerOffCommand = command(PowerOffKey)
   def powerOnCommand = command(PowerOnKey)
@@ -69,6 +73,7 @@ object PowerManagementConfig extends Configurable {
       disallowStatus
       disallowWhenAllocated
       timeoutMs
+      allowAssetsWithoutIpmi
       RequiredKeys.foreach { key =>
         val cmd = command(key)
         require(cmd.nonEmpty, "powermanagement.commands.%s must not be empty".format(key))

--- a/app/collins/power/management/PowerManagementConfig.scala
+++ b/app/collins/power/management/PowerManagementConfig.scala
@@ -54,7 +54,7 @@ object PowerManagementConfig extends Configurable {
   // allowAssetsWithoutIpmi (default: false) - If false, only allow power management of assets
   // with valid IPMI details. If true, restricts templating of the IPMI commands to
   // only <tag>.
-  def allowAssetsWithoutIpmi = getBoolean("allowAssetsWithoutIpmi").getOrElse(true)
+  def allowAssetsWithoutIpmi = getBoolean("allowAssetsWithoutIpmi").getOrElse(false)
 
   def powerOffCommand = command(PowerOffKey)
   def powerOnCommand = command(PowerOnKey)

--- a/app/collins/util/IpmiCommand.scala
+++ b/app/collins/util/IpmiCommand.scala
@@ -17,14 +17,16 @@ abstract class IpmiCommand extends BackgroundProcess[Option[CommandResult]] {
   val interval: Duration
   var debug: Boolean = false
 
-  protected def ipmiInfo: IpmiInfo
+  protected def ipmiInfo: Option[IpmiInfo]
   protected def ipmiCommand: String
 
   protected val logger = Logger(getClass)
 
-  protected lazy val (address, username, password) = {
-    val ipmi = ipmiInfo
-    (ipmi.dottedAddress(), ipmi.username, ipmi.decryptedPassword())
+  // just ignore the missing IPMI information and assume empty strings if ipmi info
+  // is missing.
+  protected lazy val (address, username, password) = ipmiInfo match {
+    case None => ("","","")
+    case Some(i) => (i.dottedAddress(), i.username, i.decryptedPassword())
   }
 
   def shouldRun(): Boolean = {

--- a/app/collins/util/PowerCommand.scala
+++ b/app/collins/util/PowerCommand.scala
@@ -12,7 +12,7 @@ import collins.shell.CommandResult
 import collins.util.concurrent.BackgroundProcess
 import collins.util.config.AppConfig
 
-abstract class IpmiCommand extends BackgroundProcess[Option[CommandResult]] {
+abstract class PowerCommand extends BackgroundProcess[Option[CommandResult]] {
   val assetTag: String
   val interval: Duration
   var debug: Boolean = false


### PR DESCRIPTION
@Primer42 @maddalab @schallert @roymarantz @tumblr/systems 
This allows collins to perform power commands on assets that do not have IPMI Information configured, if you set `powermanagement.allowAssetsWithoutIpmi = true`. 