### PR TITLE
update dockerfile to jdk8 and cleanup build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ _site
 target
 support
 vendor
+project/target

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,9 @@ MAINTAINER Gabe Conradi <gabe@tumblr.com>
 
 RUN apt-get update && apt-get install -y zip unzip && rm -r /var/lib/apt/lists/*
 
-ENV ACTIVATOR_VERSION 1.3.7
-
-# get Play, Collins, build, and deploy it to /opt/collins
 COPY . /build/collins
 RUN cd /build && \
+    export ACTIVATOR_VERSION=1.3.7 && \
     wget -q http://downloads.typesafe.com/typesafe-activator/$ACTIVATOR_VERSION/typesafe-activator-$ACTIVATOR_VERSION-minimal.zip -O /build/activator.zip && \
     unzip -q ./activator.zip && \
     cd collins && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,28 @@
-FROM java:7
+FROM java:8-jdk
 MAINTAINER Gabe Conradi <gabe@tumblr.com>
 
 RUN apt-get update && apt-get install -y zip unzip && rm -r /var/lib/apt/lists/*
 
-RUN useradd -Ur -d /opt/collins collins
-RUN for dir in /build /build/collins /var/log/collins /var/run/collins; do mkdir $dir; chown collins $dir; done
+ENV ACTIVATOR_VERSION 1.3.7
 
-WORKDIR /build
 # get Play, Collins, build, and deploy it to /opt/collins
 COPY . /build/collins
-RUN wget -q http://downloads.typesafe.com/typesafe-activator/1.3.6/typesafe-activator-1.3.6-minimal.zip -O /build/typesafe-activator-1.3.6-minimal.zip && \
-    unzip -q ./typesafe-activator-1.3.6-minimal.zip && \
+RUN cd /build && \
+    wget -q http://downloads.typesafe.com/typesafe-activator/$ACTIVATOR_VERSION/typesafe-activator-$ACTIVATOR_VERSION-minimal.zip -O /build/activator.zip && \
+    unzip -q ./activator.zip && \
     cd collins && \
     java -version 2>&1 && \
-    PLAY_CMD=/build/activator-1.3.6-minimal/activator ./scripts/package.sh && \
+    PLAY_CMD=/build/activator-$ACTIVATOR_VERSION-minimal/activator ./scripts/package.sh && \
     unzip -q /build/collins/target/collins.zip -d /opt/ && \
-    cd / && rm -rf /build && \
-    chown -R collins /opt/collins
-
-# Add in all the default configs we want in this build so collins can run.
-# Override /opt/collins/conf with your own configs with -v
-COPY conf/docker/validations.conf     /opt/collins/conf/validations.conf
-COPY conf/docker/authentication.conf  /opt/collins/conf/authentication.conf
-COPY conf/docker/database.conf        /opt/collins/conf/database.conf
-COPY conf/docker/production.conf      /opt/collins/conf/production.conf
-COPY conf/docker/users.conf           /opt/collins/conf/users.conf
-COPY conf/docker/profiles.yaml        /opt/collins/conf/profiles.yaml
-COPY conf/docker/permissions.yaml     /opt/collins/conf/permissions.yaml
-COPY conf/docker/logger.xml           /opt/collins/conf/logger.xml
-
-RUN chown -R collins /opt/collins
+    cd / && rm -rf /build
 
 WORKDIR /opt/collins
-USER collins
-EXPOSE 9000
-EXPOSE 3333
-CMD ["/usr/bin/java","-server","-Dconfig.file=/opt/collins/conf/production.conf","-Dhttp.port=9000","-Dlogger.file=/opt/collins/conf/logger.xml","-Dnetworkaddress.cache.ttl=1","-Dnetworkaddress.cache.negative.ttl=1","-Dcom.sun.management.jmxremote","-Dcom.sun.management.jmxremote.port=3333","-Dcom.sun.management.jmxremote.authenticate=false","-Dcom.sun.management.jmxremote.ssl=false","-XX:MaxPermSize=384m","-XX:+CMSClassUnloadingEnabled","-XX:+PrintGCDetails","-XX:+PrintGCTimeStamps","-XX:+PrintGCDateStamps","-XX:+PrintTenuringDistribution","-XX:+PrintHeapAtGC","-Xloggc:/var/log/collins/gc.log","-XX:+UseGCLogFileRotation","-cp","/opt/collins/lib/*","play.core.server.NettyServer","/opt/collins"]
+
+# Add in all the default configs we want in this build so collins can run.
+# You probably will want to override these configs in production
+COPY conf/docker conf/
+
+# expose HTTP, JMX
+EXPOSE 9000 3333
+CMD ["/usr/bin/java","-server","-Dconfig.file=/opt/collins/conf/production.conf","-Dhttp.port=9000","-Dlogger.file=/opt/collins/conf/logger.xml","-Dnetworkaddress.cache.ttl=1","-Dnetworkaddress.cache.negative.ttl=1","-Dcom.sun.management.jmxremote","-Dcom.sun.management.jmxremote.port=3333","-Dcom.sun.management.jmxremote.authenticate=false","-Dcom.sun.management.jmxremote.ssl=false","-XX:MaxPermSize=384m","-XX:+CMSClassUnloadingEnabled","-cp","/opt/collins/lib/*","play.core.server.NettyServer","/opt/collins"]
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,8 @@ parallelExecution in IntegrationTest := false
 
 scalaVersion := "2.11.7"
 
+autoScalaLibrary := true
+
 scalacOptions ++= Seq("-deprecation","-unchecked", "-feature")
 
 scalacOptions += "-feature"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -7,11 +7,8 @@ object ApplicationBuild extends Build {
     val appName         = "collins"
     val appVersion      = "2.0-SNAPSHOT"
 
-    val appDependencies = Seq()
-
     val main = Project(appName, file(".")).enablePlugins(play.PlayScala).settings(
       version := appVersion,
-      libraryDependencies ++= appDependencies,
       TwirlKeys.templateImports ++= Seq(
         "collins.models._", 
         "collins.models.shared._", 


### PR DESCRIPTION
@tumblr/systems This dockerfile has gone unloved for a while, so I thought I would simplify and cleanup some. This appears to improve startup times drastically (not writing GC logs to the overlay FS helps :P). JDK bumped to 8, activator to 1.3.7.