### PR TITLE
Include solr query string in cache key

### DIFF
--- a/app/collins/models/AssetFinder.scala
+++ b/app/collins/models/AssetFinder.scala
@@ -54,7 +54,7 @@ case class AssetFinder(
       updatedAfter.map(t => "updatedAfter" -> Formatter.dateFormat(t)) ::
       updatedBefore.map(t => "updatedBefore" -> Formatter.dateFormat(t)) ::
       state.map(s => "state" -> s.name) ::
-      query.map { q => "query" -> "UHOH!!!!" } :: //FIXME: need toCQL traversal
+      query.map(q => "query" -> q.traverseQueryString) ::
       Nil)
     items.flatten
   }

--- a/app/collins/models/RemoteAssetFinder.scala
+++ b/app/collins/models/RemoteAssetFinder.scala
@@ -276,7 +276,7 @@ object RemoteAssetFinder {
   /**
    */
   def apply(clients: Seq[RemoteAssetClient], pageParams: PageParams, searchParams: AssetSearchParameters): (Seq[AssetView], Long) = {
-    val key = searchParams.paginationKey + clients.map { _.tag }.mkString("_")
+    val key = searchParams.paginationKey.getOrElse("") + clients.map { _.tag }.mkString("_")
     val stream = Cache.getAs[RemoteAssetStream](key).getOrElse(new RemoteAssetStream(clients, searchParams))
     val results = stream.slice(pageParams.page * pageParams.size, (pageParams.page + 1) * (pageParams.size))
     Cache.set(key, stream, 30)

--- a/app/collins/models/RemoteAssetFinder.scala
+++ b/app/collins/models/RemoteAssetFinder.scala
@@ -26,6 +26,7 @@ import collins.solr.SolrOrOp
 import collins.solr.StringValueFormat
 import collins.util.AttributeResolver.ResultTuple
 import collins.util.RemoteCollinsHost
+import collins.util.config.MultiCollinsConfig
 
 /**
  * Just a combination of everything needed to do a search.  Probably should
@@ -279,7 +280,8 @@ object RemoteAssetFinder {
     val key = searchParams.paginationKey.getOrElse("") + clients.map { _.tag }.mkString("_")
     val stream = Cache.getAs[RemoteAssetStream](key).getOrElse(new RemoteAssetStream(clients, searchParams))
     val results = stream.slice(pageParams.page * pageParams.size, (pageParams.page + 1) * (pageParams.size))
-    Cache.set(key, stream, 30)
+    val timeout = MultiCollinsConfig.queryCacheTimeout
+    Cache.set(key, stream, timeout)
     (results, stream.aggregateTotal)
   }
 

--- a/app/collins/solr/CollinsQueryLanguage.scala
+++ b/app/collins/solr/CollinsQueryLanguage.scala
@@ -27,7 +27,7 @@ case class CQLQuery(select: SolrDocType, where: SolrExpression) {
  * itself into a Solr Query
  */
 sealed trait SolrQueryComponent {
-  protected[solr] def traverseQueryString(): String = traverseQueryString(true)
+  def traverseQueryString(): String = traverseQueryString(true)
   protected[solr] def traverseQueryString(toplevel: Boolean): String
 }
 

--- a/app/collins/util/config/MultiCollinsConfig.scala
+++ b/app/collins/util/config/MultiCollinsConfig.scala
@@ -18,6 +18,7 @@ object MultiCollinsConfig extends Configurable {
   }
   def locationAttribute = getString("locationAttribute", "LOCATION")
   def thisInstance = getString("thisInstance")
+  def queryCacheTimeout = getInt("queryCacheTimeout", 30)
 
   override def validateConfig() {
     if (enabled) {

--- a/conf/reference/multicollins_reference.conf
+++ b/conf/reference/multicollins_reference.conf
@@ -3,4 +3,5 @@ multicollins {
   instanceAssetType = DATA_CENTER
   locationAttribute = LOCATION
   thisInstance = NONE
+  queryCacheTimeout = 30
 }

--- a/test/collins/models/AssetSearchParametersSpec.scala
+++ b/test/collins/models/AssetSearchParametersSpec.scala
@@ -3,6 +3,9 @@ package collins.models
 import org.specs2._
 import specification._
 
+import collins.solr.SolrKeyVal
+import collins.solr.SolrStringValue
+
 class AssetSearchParametersSpec extends mutable.Specification {
 
   val EMPTY_RESULT_TUPLE = (Nil, Nil, Nil)
@@ -91,6 +94,10 @@ class AssetSearchParametersSpec extends mutable.Specification {
           AssetFinder.empty,
           None
         ).toSeq.findOne("attribute") must_== Some("ip_address;1.3.5.7")
+      }
+
+      "include CQL query" in {
+        AssetSearchParameters(EMPTY_RESULT_TUPLE, AssetFinder.empty.copy(query = Some(SolrKeyVal("foo", SolrStringValue("bar")))), None).toSeq.findOne("query") must_== Some("foo:\"bar\"")
       }
 
     }


### PR DESCRIPTION
When doing queries across many collins instances (using multi-collins) we cache the response from the remote instances for 30 seconds. The problem is that we do not include the CQL query in the key which can result in two different queries returning the same thing.

This PR changes the behavior by adding the solr query string to the cache key, which should eliminate the problem. I'm "unprotecting" `traverseQueryString()` but I think that should be fine as the method doesn't modify or remove anything, it just traverses the solr expression and builds the query string.

@tumblr/systems rfr