### PR TITLE
Make remote query cache timeout configurable

### DIFF
--- a/app/collins/models/RemoteAssetFinder.scala
+++ b/app/collins/models/RemoteAssetFinder.scala
@@ -26,6 +26,7 @@ import collins.solr.SolrOrOp
 import collins.solr.StringValueFormat
 import collins.util.AttributeResolver.ResultTuple
 import collins.util.RemoteCollinsHost
+import collins.util.config.MultiCollinsConfig
 
 /**
  * Just a combination of everything needed to do a search.  Probably should
@@ -279,7 +280,8 @@ object RemoteAssetFinder {
     val key = searchParams.paginationKey + clients.map { _.tag }.mkString("_")
     val stream = Cache.getAs[RemoteAssetStream](key).getOrElse(new RemoteAssetStream(clients, searchParams))
     val results = stream.slice(pageParams.page * pageParams.size, (pageParams.page + 1) * (pageParams.size))
-    Cache.set(key, stream, 30)
+    val timeout = MultiCollinsConfig.queryCacheTimeout
+    Cache.set(key, stream, timeout)
     (results, stream.aggregateTotal)
   }
 

--- a/app/collins/util/config/MultiCollinsConfig.scala
+++ b/app/collins/util/config/MultiCollinsConfig.scala
@@ -18,6 +18,7 @@ object MultiCollinsConfig extends Configurable {
   }
   def locationAttribute = getString("locationAttribute", "LOCATION")
   def thisInstance = getString("thisInstance")
+  def queryCacheTimeout = getInt("queryCacheTimeout", 30)
 
   override def validateConfig() {
     if (enabled) {

--- a/conf/reference/multicollins_reference.conf
+++ b/conf/reference/multicollins_reference.conf
@@ -3,4 +3,5 @@ multicollins {
   instanceAssetType = DATA_CENTER
   locationAttribute = LOCATION
   thisInstance = NONE
+  queryCacheTimeout = 30
 }


### PR DESCRIPTION
Fixing the problems with multi-collins queries as described in #396 (and reverted in #400) is taking a bit longer than i had hoped. So, in the meantime, this PR re-introduces the config parameter for the remote query cache timeout from the previous PR.

@tumblr/collins 