### PR TITLE
Consolr updates

### DIFF
--- a/support/ruby/consolr/bin/consolr
+++ b/support/ruby/consolr/bin/consolr
@@ -21,6 +21,7 @@ opt_parser = OptionParser.new do |opt|
   opt.on('-s', '--sdr',             'Sensor Data Repository (SDR)')            { options[:sdr] = true }
   opt.on('-t', '--tag ASSET',       'asset tag')                               { |tag| options[:tag] = tag }
   opt.on('-x', '--off',             'turn off node')                           { options[:off] = true }
+  opt.on('-S', '--status',          'print asset power status')                { options[:status] = true }
 
   opt.on_tail('-h', '--help', 'help') { puts opt; exit 0 }
   opt.on_tail('-v', '--version', 'version') { puts Consolr::VERSION; exit 0 }

--- a/support/ruby/consolr/bin/consolr
+++ b/support/ruby/consolr/bin/consolr
@@ -18,9 +18,11 @@ opt_parser = OptionParser.new do |opt|
   opt.on('-l', '--log LOG',         'System Event Log (SEL) [list|clear]')     { |log| options[:log] = log }
   opt.on('-o', '--on',              'turn on node')                            { options[:on] = true }
   opt.on('-r', '--reboot',          'restart node')                            { options[:reboot] = true }
+  opt.on('-R', '--soft-reboot',     'restart node gracefully')                 { options[:soft_reboot] = true }
   opt.on('-s', '--sdr',             'Sensor Data Repository (SDR)')            { options[:sdr] = true }
   opt.on('-t', '--tag ASSET',       'asset tag')                               { |tag| options[:tag] = tag }
   opt.on('-x', '--off',             'turn off node')                           { options[:off] = true }
+  opt.on('-X', '--soft-off',        'turn off gracefully (via ACPI)')          { options[:soft_off] = true }
   opt.on('-S', '--status',          'print asset power status')                { options[:status] = true }
 
   opt.on_tail('-h', '--help', 'help') { puts opt; exit 0 }

--- a/support/ruby/consolr/bin/consolr
+++ b/support/ruby/consolr/bin/consolr
@@ -24,6 +24,7 @@ opt_parser = OptionParser.new do |opt|
   opt.on('-x', '--off',             'turn off node')                           { options[:off] = true }
   opt.on('-X', '--soft-off',        'turn off gracefully (via ACPI)')          { options[:soft_off] = true }
   opt.on('-S', '--status',          'print asset power status')                { options[:status] = true }
+  opt.on('--runner RUNNER',         'specify the runner to use')               { |runner| options[:runner] = runner }
 
   opt.on_tail('-h', '--help', 'help') { puts opt; exit 0 }
   opt.on_tail('-v', '--version', 'version') { puts Consolr::VERSION; exit 0 }

--- a/support/ruby/consolr/lib/consolr.rb
+++ b/support/ruby/consolr/lib/consolr.rb
@@ -5,7 +5,7 @@ require 'collins_auth'
 require 'optparse'
 require 'yaml'
 
-require 'consolr/runners'
+require 'consolr/runners/ipmitool'
 
 module Consolr
   class Console

--- a/support/ruby/consolr/lib/consolr.rb
+++ b/support/ruby/consolr/lib/consolr.rb
@@ -148,8 +148,12 @@ module Consolr
         puts runner.on @node
       when options[:off]
         puts runner.off @node
+      when options[:soft_off]
+        puts runner.soft_off @node
       when options[:reboot]
         puts runner.reboot @node
+      when options[:soft_reboot]
+        puts runner.soft_reboot @node
       when options[:status]
         puts runner.status @node
       else

--- a/support/ruby/consolr/lib/consolr.rb
+++ b/support/ruby/consolr/lib/consolr.rb
@@ -114,7 +114,7 @@ module Consolr
       }.first
 
       if runner.nil?
-        abort("No runners available for node #{@node.hostname} (#{@node.tag})")
+        abort("No runners available for node #{@node.hostname} (#{@node.tag})")
       end
 
       if not runner.verify @node
@@ -150,6 +150,8 @@ module Consolr
         puts runner.off @node
       when options[:reboot]
         puts runner.reboot @node
+      when options[:status]
+        puts runner.status @node
       else
         begin
           puts "specify an action"

--- a/support/ruby/consolr/lib/consolr/runners.rb
+++ b/support/ruby/consolr/lib/consolr/runners.rb
@@ -1,0 +1,58 @@
+require 'net/ping'
+
+module Consolr
+  module Runners
+    class Ipmitool
+      def initialize config
+				@ipmitool = config['executable']
+      end
+
+			def verify? node
+      	Net::Ping::External.new(node.ipmi.address).ping?
+			end
+
+      def console node
+        cmd 'sol activate', node
+      end
+
+      def kick node
+        cmd 'sol dectivate', node
+      end
+
+      def identify node
+        cmd 'identify', node
+      end
+
+      def sdr node
+        cmd 'sdr elist all', node
+      end
+
+      def log_list node
+        cmd 'sel list', node
+      end
+
+      def log_clear node
+        cmd 'sel clear', node
+      end
+
+      def on node
+        cmd 'power on', node
+      end
+
+      def off node
+        cmd 'power off', node
+      end
+
+      def reboot node
+        cmd 'power cycle', node
+      end
+
+      private
+      def cmd action, node
+        system("#{@ipmitool} -I lanplus -H #{node.ipmi.address} -U #{node.ipmi.username} -P #{node.ipmi.password} #{action}")
+        return $?.exitstatus == 0 ? "SUCCESS" : "FAILED"
+      end
+    end
+  end
+end
+              

--- a/support/ruby/consolr/lib/consolr/runners/ipmitool.rb
+++ b/support/ruby/consolr/lib/consolr/runners/ipmitool.rb
@@ -55,8 +55,16 @@ module Consolr
         cmd 'power off', node
       end
 
+      def soft_off node
+        cmd 'power soft', node
+      end
+
       def reboot node
         cmd 'power cycle', node
+      end
+
+      def soft_reboot node
+        cmd 'power reset', node
       end
 
       def status node

--- a/support/ruby/consolr/lib/consolr/runners/ipmitool.rb
+++ b/support/ruby/consolr/lib/consolr/runners/ipmitool.rb
@@ -4,10 +4,18 @@ module Consolr
   module Runners
     class Ipmitool < Runner
       def initialize config
-				@ipmitool = config['executable']
+        @ipmitool = if config.empty?
+                      '/usr/bin/ipmitool'
+                    else
+                      config
+                    end
       end
 
-			def verify? node
+      def can_run? node
+        not (node.ipmi.address.empty? or node.ipmi.username.empty? or node.ipmi.password.empty?)
+      end
+
+			def verify node
       	Net::Ping::External.new(node.ipmi.address).ping?
 			end
 
@@ -16,11 +24,11 @@ module Consolr
       end
 
       def kick node
-        cmd 'sol dectivate', node
+        cmd 'sol deactivate', node
       end
 
       def identify node
-        cmd 'identify', node
+        cmd 'chassis identify', node
       end
 
       def sdr node

--- a/support/ruby/consolr/lib/consolr/runners/ipmitool.rb
+++ b/support/ruby/consolr/lib/consolr/runners/ipmitool.rb
@@ -15,9 +15,9 @@ module Consolr
         not (node.ipmi.address.empty? or node.ipmi.username.empty? or node.ipmi.password.empty?)
       end
 
-			def verify node
-      	Net::Ping::External.new(node.ipmi.address).ping?
-			end
+      def verify node
+        Net::Ping::External.new(node.ipmi.address).ping?
+      end
 
       def console node
         cmd 'sol activate', node

--- a/support/ruby/consolr/lib/consolr/runners/ipmitool.rb
+++ b/support/ruby/consolr/lib/consolr/runners/ipmitool.rb
@@ -1,8 +1,8 @@
-require 'net/ping'
+require 'consolr/runners/runner'
 
 module Consolr
   module Runners
-    class Ipmitool
+    class Ipmitool < Runner
       def initialize config
 				@ipmitool = config['executable']
       end
@@ -55,4 +55,4 @@ module Consolr
     end
   end
 end
-              
+

--- a/support/ruby/consolr/lib/consolr/runners/ipmitool.rb
+++ b/support/ruby/consolr/lib/consolr/runners/ipmitool.rb
@@ -12,7 +12,11 @@ module Consolr
       end
 
       def can_run? node
-        not (node.ipmi.address.empty? or node.ipmi.username.empty? or node.ipmi.password.empty?)
+        begin
+          not (node.ipmi.address.empty? or node.ipmi.username.empty? or node.ipmi.password.empty?)
+        rescue
+          false
+        end
       end
 
       def verify node

--- a/support/ruby/consolr/lib/consolr/runners/ipmitool.rb
+++ b/support/ruby/consolr/lib/consolr/runners/ipmitool.rb
@@ -55,6 +55,10 @@ module Consolr
         cmd 'power cycle', node
       end
 
+      def status node
+        cmd 'power status', node
+      end
+
       private
       def cmd action, node
         system("#{@ipmitool} -I lanplus -H #{node.ipmi.address} -U #{node.ipmi.username} -P #{node.ipmi.password} #{action}")

--- a/support/ruby/consolr/lib/consolr/runners/runner.rb
+++ b/support/ruby/consolr/lib/consolr/runners/runner.rb
@@ -7,9 +7,9 @@ module Consolr
         raise 'can_run? is not implemented for this runner'
       end
 
-			def verify node
+      def verify node
         raise 'verify is not implemented for this runner'
-			end
+      end
 
       def console node
         raise 'console is not implemented for this runner'

--- a/support/ruby/consolr/lib/consolr/runners/runner.rb
+++ b/support/ruby/consolr/lib/consolr/runners/runner.rb
@@ -43,8 +43,16 @@ module Consolr
         raise 'power off is not implemented for this runner'
       end
 
+      def soft_off node
+        raise 'soft_off is not implemented for this runner'
+      end
+
       def reboot node
         raise 'reboot is not implemented for this runner'
+      end
+
+      def soft_reboot node
+        raise 'reboot_soft is not implemented for this runner'
       end
 
       def status node

--- a/support/ruby/consolr/lib/consolr/runners/runner.rb
+++ b/support/ruby/consolr/lib/consolr/runners/runner.rb
@@ -1,0 +1,52 @@
+require 'net/ping'
+
+module Consolr
+  module Runners
+    class Runner
+      def can_run? node
+        raise 'can_run? is not implemented for this runner'
+      end
+
+			def verify node
+        raise 'verify is not implemented for this runner'
+			end
+
+      def console node
+        raise 'console is not implemented for this runner'
+      end
+
+      def kick node
+        raise 'kick is not implemented for this runner'
+      end
+
+      def identify node
+        raise 'identify is not implemented for this runner'
+      end
+
+      def sdr node
+        raise 'sdr is not implemented for this runner'
+      end
+
+      def log_list node
+        raise 'log list is not implemented for this runner'
+      end
+
+      def log_clear node
+        raise 'log clear is not implemented for this runner'
+      end
+
+      def on node
+        raise 'power on is not implemented for this runner'
+      end
+
+      def off node
+        raise 'power off is not implemented for this runner'
+      end
+
+      def reboot node
+        raise 'reboot is not implemented for this runner'
+      end
+    end
+  end
+end
+              

--- a/support/ruby/consolr/lib/consolr/runners/runner.rb
+++ b/support/ruby/consolr/lib/consolr/runners/runner.rb
@@ -46,6 +46,10 @@ module Consolr
       def reboot node
         raise 'reboot is not implemented for this runner'
       end
+
+      def status node
+        raise 'status is not implemented for this runner'
+      end
     end
   end
 end

--- a/support/ruby/consolr/lib/consolr/version.rb
+++ b/support/ruby/consolr/lib/consolr/version.rb
@@ -1,3 +1,3 @@
 module Consolr
-  VERSION = "1.0.2"
+  VERSION = "1.1.0"
 end

--- a/support/ruby/consolr/spec/configs/consolr_runners_rspec.yml
+++ b/support/ruby/consolr/spec/configs/consolr_runners_rspec.yml
@@ -1,0 +1,9 @@
+# this is a dummy config for the unit tests
+runners:
+  - failrunner
+  - testrunner
+dangerous_assets:
+  - "dangerous-allocated-tag"
+  - "dangerous-maintenance-tag"
+dangerous_status:
+  - "Allocated"

--- a/support/ruby/consolr/spec/consolr_spec.rb
+++ b/support/ruby/consolr/spec/consolr_spec.rb
@@ -26,6 +26,24 @@ describe Consolr::Console do
     expect { @console.start({:hostname => 'hostname-with-multiple-assets.dc.net'}) }.to raise_error(SystemExit, /Found \d+ assets/)
   end
 
+  it 'loads ipmitool as the default runner' do
+    expect_any_instance_of(Consolr::Runners::Ipmitool).to receive(:initialize)
+    @console.start({:tag => 'safe-allocated-tag', :on => true})
+  end
+
+  it 'prints an error when passed an unknown runner' do
+    expect {
+      @console.start({:tag => 'safe-allocated-tag', :on  => true, :runner => 'bogusrunner'})
+    }.to raise_error SystemExit
+  end
+
+  it 'loads a custom runner when specified' do
+    $LOAD_PATH << 'spec/mocks'
+    require 'consolr/runners/testrunner'
+    expect_any_instance_of(Consolr::Runners::Testrunner).to receive(:initialize)
+    @console.start({:tag => 'safe-allocated-tag', :on => true, :runner => 'testrunner'})
+  end
+
   safe_boolean_actions = {:console => "--> Opening SOL session (type ~~. to quit)\nsol activate", :kick => 'sol deactivate', :identify => 'chassis identify', :sdr => 'sdr elist all', :on => 'power on'}
   dangerous_boolean_actions = {:off => 'power off', :reboot => 'power cycle'}
 

--- a/support/ruby/consolr/spec/consolr_spec.rb
+++ b/support/ruby/consolr/spec/consolr_spec.rb
@@ -44,6 +44,22 @@ describe Consolr::Console do
     @console.start({:tag => 'safe-allocated-tag', :on => true, :runner => 'testrunner'})
   end
 
+  it 'selects a runner that supports the node' do
+    $LOAD_PATH << 'spec/mocks'
+    require 'consolr/runners/testrunner'
+    require 'consolr/runners/failrunner'
+    old_config = ENV['CONSOLR_CONFIG']
+    ENV['CONSOLR_CONFIG'] = '../../spec/configs/consolr_runners_rspec.yml'
+
+    console = Consolr::Console.new
+    expect_any_instance_of(Consolr::Runners::Failrunner).to receive(:can_run?).
+      and_return(false)
+    expect_any_instance_of(Consolr::Runners::Testrunner).to receive(:on)
+    console.start({:tag => 'safe-allocated-tag', :on => true})
+
+    ENV['CONSOLR_CONFIG'] = old_config
+  end
+
   safe_boolean_actions = {:console => "--> Opening SOL session (type ~~. to quit)\nsol activate", :kick => 'sol deactivate', :identify => 'chassis identify', :sdr => 'sdr elist all', :on => 'power on'}
   dangerous_boolean_actions = {:off => 'power off', :reboot => 'power cycle'}
 

--- a/support/ruby/consolr/spec/mocks/consolr/runners/failrunner.rb
+++ b/support/ruby/consolr/spec/mocks/consolr/runners/failrunner.rb
@@ -1,7 +1,7 @@
 module Consolr
   module Runners
-    class Testrunner < Runner
-      def initialize
+    class Failrunner < Runner
+      def initialize config
         true
       end
 

--- a/support/ruby/consolr/spec/mocks/consolr/runners/failrunner.rb
+++ b/support/ruby/consolr/spec/mocks/consolr/runners/failrunner.rb
@@ -1,0 +1,13 @@
+module Consolr
+  module Runners
+    class Testrunner < Runner
+      def initialize
+        true
+      end
+
+      def can_run? node
+        false
+      end
+    end
+  end
+end

--- a/support/ruby/consolr/spec/mocks/consolr/runners/testrunner.rb
+++ b/support/ruby/consolr/spec/mocks/consolr/runners/testrunner.rb
@@ -1,0 +1,25 @@
+module Consolr
+  module Runners
+    class Testrunner < Runner
+      def initialize
+        true
+      end
+
+      def can_run? node
+        true
+      end
+
+      def verify node
+        true
+      end
+
+      def on node
+        'SUCCESS'
+      end
+
+      def power node
+        'SUCCESS'
+      end
+    end
+  end
+end

--- a/support/ruby/consolr/spec/mocks/consolr/runners/testrunner.rb
+++ b/support/ruby/consolr/spec/mocks/consolr/runners/testrunner.rb
@@ -1,7 +1,7 @@
 module Consolr
   module Runners
     class Testrunner < Runner
-      def initialize
+      def initialize config
         true
       end
 


### PR DESCRIPTION
In order to support more tools than ipmitool in consolr, I'd like to modularize it a bit. As you can see here, I've moved all the ipmitool-related code in to a class called `Consolr::Runners::Ipmitool`. The command loads one or more runners dynamically from the config, and chooses the first one that reports it can run on a given node (meaning the runner's `can_run?` method returns true). 

An example use case could be an environment with mixed Openstack VMs and bare metal servers. An openstack runner would then handle all the VM assets and the ipmitool runner all the bare metal assets. This way, you can easily customize consolr to new tools by writing a `Consolr::Runners::Yourtool` class and then installing it in whichever way you prefer.

In order to maintain backwards compatibility I've made the ipmitool runner the default if no runners are specified in the config.

Finally, I'm adding an option (`-S`, or `--status`) which just returns the power status of the assets because it seemed like something that would be useful :)

@tumblr/collins 