### PR TITLE
Document allowAssetsWithoutIpmi configuration option

### DIFF
--- a/_includes/configuration/powermgmt.html
+++ b/_includes/configuration/powermgmt.html
@@ -36,6 +36,11 @@ them or powering them off, you will want to provide a power management configura
       <td>Asset types that can be power managed. Defaults to [SERVER_NODE].</td>
     </tr>
     <tr>
+      <td class="inlinecode">allowAssetsWithoutIpmi</td>
+      <td>Boolean</td>
+      <td>Allow power actions on assets that do not have IPMI information. Defaults to false.</td>
+    </tr>
+    <tr>
       <td class="inlinecode">disallowStatus</td>
       <td>Set[String]</td>
       <td>Set of status types where power management should not be enabled. Defaults to empty set.</td>
@@ -57,6 +62,11 @@ them or powering them off, you will want to provide a power management configura
 <pre>powermanagement {
   enabled = true
   command_template = "ipmitool -H &lt;host&gt; -U &lt;username&gt; -P &lt;password&gt; -I lan -L OPERATOR"
+
+  allowAssetTypes = [SERVER_NODE]
+  allowAssetsWithoutIpmi = false
+  disallowStatus = []
+  disallowWhenAllocated = [powerOff]
 
   commands {
     powerOff = ${powermanagement.command_template}" chassis power off"


### PR DESCRIPTION
As the title says, adding documentation for the `allowAssetsWithoutIpmi` power management configuration option. It was added in #388. I'm also adding a couple of things to the example configuration that were missing before.

@tumblr/collins 