### PR TITLE
[docs] akka: update for change_queue_processor

### DIFF
--- a/_includes/configuration/thread_pools.html
+++ b/_includes/configuration/thread_pools.html
@@ -7,10 +7,6 @@
 Configuring Collins akka pools is relatively straightforward. See the akka documentation for details. Collins makes use of a single akka dispatcher which can be configured in <code>akka.actor.default-dispatcher</code>. The dispatcher is shared for background processes and solr updates
 </p>
 
-<p>
-<span class="label label-note">Note</span> Currently only on the development branch, scheduled for future release.
-</p>
-
 <table class="table table-condensed table-hover">
   <thead>
     <tr>
@@ -20,15 +16,19 @@ Configuring Collins akka pools is relatively straightforward. See the akka docum
   <tbody>
     <tr>
       <td class="inlinecode">background-processor</td>
-      <td>Configure for background processes, for instance ipmi invocations</td>
+      <td>Configuration for background processes (such as ipmi invocations)</td>
     </tr>
     <tr>
       <td class="inlinecode">solr_asset_updater</td>
-      <td>Configure for solr updates on asset modification</td>
+      <td>Configuration for solr updates on asset modification</td>
     </tr>
     <tr>
       <td class="inlinecode">solr_asset_log_updater</td>
-      <td>Configure for updates on asset log modification</td>
+      <td>Configuration for solr updates on asset log modification</td>
+    </tr>
+    <tr>
+      <td class="inlinecode">change_queue_processor</td>
+      <td>Configuration for internal callbacks (such as firehose events)</td>
     </tr>
   </tbody>
 </table>
@@ -54,6 +54,10 @@ Configuring Collins akka pools is relatively straightforward. See the akka docum
       }
 
       /solr_asset_log_updater = {
+        dispatcher = default-dispatcher
+      }
+
+      /change_queue_processor = {
         dispatcher = default-dispatcher
       }
     }


### PR DESCRIPTION
The changes in https://github.com/tumblr/collins/pull/283 necessitate some changes to the Akka dispatcher config. To reflect those, I've added the `change_queue_processor` dispatcher config to the docs for Akka configs.

I changed some of the other Akka config docs just to standardize the phrasing, and also remove the part about this being in devel since our next release will include it.

RFR @tumblr/systems 