### PR TITLE
Add support for sensor reading

### DIFF
--- a/support/ruby/consolr/bin/consolr
+++ b/support/ruby/consolr/bin/consolr
@@ -24,6 +24,7 @@ opt_parser = OptionParser.new do |opt|
   opt.on('-x', '--off',             'turn off node')                           { options[:off] = true }
   opt.on('-X', '--soft-off',        'turn off gracefully (via ACPI)')          { options[:soft_off] = true }
   opt.on('-S', '--status',          'print asset power status')                { options[:status] = true }
+  opt.on('-L', '--sensors',         'print list of sensor values')             { options[:sensors] = true }
   opt.on('--runner RUNNER',         'specify the runner to use')               { |runner| options[:runner] = runner }
 
   opt.on_tail('-h', '--help', 'help') { puts opt; exit 0 }

--- a/support/ruby/consolr/lib/consolr.rb
+++ b/support/ruby/consolr/lib/consolr.rb
@@ -155,6 +155,8 @@ module Consolr
         puts runner.soft_reboot @node
       when options[:status]
         puts runner.status @node
+      when options[:sensors]
+        puts runner.sensors @node
       else
         begin
           puts "specify an action"

--- a/support/ruby/consolr/lib/consolr/runners/ipmitool.rb
+++ b/support/ruby/consolr/lib/consolr/runners/ipmitool.rb
@@ -71,6 +71,10 @@ module Consolr
         cmd 'power status', node
       end
 
+      def sensors node
+        cmd 'sensor list', node
+      end
+
       private
       def cmd action, node
         system("#{@ipmitool} -I lanplus -H #{node.ipmi.address} -U #{node.ipmi.username} -P #{node.ipmi.password} #{action}")

--- a/support/ruby/consolr/lib/consolr/runners/runner.rb
+++ b/support/ruby/consolr/lib/consolr/runners/runner.rb
@@ -58,6 +58,10 @@ module Consolr
       def status node
         raise 'status is not implemented for this runner'
       end
+
+      def sensors node
+        raise 'sensors is not implemented for this runner'
+      end
     end
   end
 end

--- a/support/ruby/consolr/lib/consolr/version.rb
+++ b/support/ruby/consolr/lib/consolr/version.rb
@@ -1,3 +1,3 @@
 module Consolr
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
`ipmitool sensor list` spits out a long list of sensors, their value and their configured thresholds. `sdr elist all` gives a similar list, but without some of the information so i'd like to add support to grab the full sensors output.

@tumblr/collins 