### PR TITLE
add a flag for consolor to print SOL info

### DIFF
--- a/support/ruby/consolr/bin/consolr
+++ b/support/ruby/consolr/bin/consolr
@@ -12,6 +12,7 @@ opt_parser = OptionParser.new do |opt|
   opt.on('-c', '--console',         'console into node via SOL')               { options[:console] = true }
   opt.on('-d', '--dangerous',       'list dangerous stuff')                    { options[:dangerous] = true }
   opt.on('-f', '--force',           'force run dangerous actions')             { options[:force] = true }
+  opt.on('-g', '--get-sol-info',    'get Serial Over LAN (SOL) info')          { options[:get_sol_info] = true }
   opt.on('-H', '--hostname ASSET',  'asset hostname')                          { |hostname| options[:hostname] = hostname }
   opt.on('-i', '--identify',        'turn on chassis UID')                     { options[:identify] = true }
   opt.on('-k', '--kick',            'kick if someone is hogging the console')  { options[:kick] = true }

--- a/support/ruby/consolr/lib/consolr.rb
+++ b/support/ruby/consolr/lib/consolr.rb
@@ -157,6 +157,8 @@ module Consolr
         puts runner.status @node
       when options[:sensors]
         puts runner.sensors @node
+      when options[:get_sol_info]
+        puts runner.sol_info @node
       else
         begin
           puts "specify an action"

--- a/support/ruby/consolr/lib/consolr/runners/ipmitool.rb
+++ b/support/ruby/consolr/lib/consolr/runners/ipmitool.rb
@@ -75,6 +75,10 @@ module Consolr
         cmd 'sensor list', node
       end
 
+      def sol_info node
+        cmd 'session info active', node
+      end
+
       private
       def cmd action, node
         system("#{@ipmitool} -I lanplus -H #{node.ipmi.address} -U #{node.ipmi.username} -P #{node.ipmi.password} #{action}")

--- a/support/ruby/consolr/lib/consolr/runners/runner.rb
+++ b/support/ruby/consolr/lib/consolr/runners/runner.rb
@@ -62,6 +62,10 @@ module Consolr
       def sensors node
         raise 'sensors is not implemented for this runner'
       end
+
+      def sol_info node
+        raise 'sol info is not implemented for this runner'
+      end
     end
   end
 end

--- a/support/ruby/consolr/lib/consolr/version.rb
+++ b/support/ruby/consolr/lib/consolr/version.rb
@@ -1,3 +1,3 @@
 module Consolr
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end


### PR DESCRIPTION
Adding SOL info for the host we wish to connect to. This can give us session info in case we need to need to dig deeper into session count and handles.

usage -- `consolr --tag <asset_tag> --sol-info`

example output

```
session handle                : 122
slot count                    : 36
active sessions               : 1
user id                       : 2
privilege level               : ADMINISTRATOR
session type                  : IPMIv2/RMCP+
channel number                : 0x01
console ip                    : 10.11.12.13
console mac                   : 4c:26:24:4e:da:21
console port                  : 29854

```