### PR TITLE
add /usr array of java_home locations

### DIFF
--- a/scripts/collins.sh
+++ b/scripts/collins.sh
@@ -64,7 +64,7 @@ function find_java() {
   if [ ! -z "$JAVA_HOME" ]; then
     return
   fi
-  for dir in /opt/jdk /System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK/Home /usr/java/default; do
+  for dir in /opt/jdk /System/Library/Frameworks/JavaVM.framework/Versions/CurrentJDK/Home /usr/java/default /usr; do
     if [ -x $dir/bin/java ]; then
       JAVA_HOME=$dir
       break


### PR DESCRIPTION
open-jdk-1.8 for centos 6 installs into `/usr/bin/java`.  Adding `/usr` to the JAVA_HOME array lets it find it easily.