### PR TITLE
Consolr lazy load runners

### DIFF
--- a/support/ruby/consolr/.gitignore
+++ b/support/ruby/consolr/.gitignore
@@ -1,1 +1,3 @@
+.bundle
 coverage/
+vendor/

--- a/support/ruby/consolr/consolr.gemspec
+++ b/support/ruby/consolr/consolr.gemspec
@@ -6,8 +6,8 @@ require 'consolr/version'
 Gem::Specification.new do |spec|
   spec.name          = "consolr"
   spec.version       = Consolr::VERSION
-  spec.authors       = ["Will Richard", "Sashidhar Guntury"]
-  spec.email         = ["will@tumblr.com", "sashi@tumblr.com", "collins-sm@googlegroups.com"]
+  spec.authors       = ["Will Richard", "Sashidhar Guntury", "Felix Aronsson"]
+  spec.email         = ["collins-sm@googlegroups.com"]
   spec.summary       = %q{consolr is a pure ruby wrapper over IPMI to allow Out of Band communiation with nodes.}
   spec.description   = %q{Consolr is a utility which speaks to Collins on our behalf and retrieves the address, username and password to connect to that node over IPMI. Passing different flags, we can performs a variety of taks on the node over IPMI. There are safeguards in place to prevent potentially catastrophic actions being performed on nodes.}
   spec.homepage      = "https://github.com/tumblr/collins/tree/master/support/ruby/consolr"
@@ -18,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "collins_auth", "~> 0.1.2"
-  spec.add_runtime_dependency "net-ping", "~> 1.7.7"
+  spec.add_runtime_dependency "collins_auth", "~> 0.1"
+  spec.add_runtime_dependency "net-ping", "~> 1.7"
 
-  spec.add_development_dependency "rake", "~> 10.4.2"
-  spec.add_development_dependency "rspec", "~> 3.3.0"
-  spec.add_development_dependency "simplecov", "~> 0.10.0"
-  spec.add_development_dependency "webmock", "~> 1.21.0"
+  spec.add_development_dependency "rake", "~> 10.4"
+  spec.add_development_dependency "rspec", "~> 3.3"
+  spec.add_development_dependency "simplecov", "~> 0.10"
+  spec.add_development_dependency "webmock", "~> 1.21"
 end

--- a/support/ruby/consolr/lib/consolr/version.rb
+++ b/support/ruby/consolr/lib/consolr/version.rb
@@ -1,3 +1,3 @@
 module Consolr
-  VERSION = "1.1.4"
+  VERSION = "1.1.5"
 end


### PR DESCRIPTION
That is, wait until we are going to use a runner before we load it.

When we run consolr a lot on one server, the server will run out of resources and lock up.

We think loading runners with lots of dependencies takes a lot of resources, so I want to try to load
the runners we use more often earlier, and not load bigger, less used runners if they aren't needed.

@defect @roymarantz @sushruta @schallert @qx-xp 