### PR TITLE
Add download link for 2.0.0

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -24,6 +24,22 @@ desc: Collins Releases
           <h1>Downloads</h1>
         </div>
         <ul>
+            <li>2016/09/19 - <a href="https://github.com/tumblr/collins/releases/download/v2.0.0/collins-v2.0.0.zip">2.0.0</a></li>
+            <p>
+                Major highlights:
+
+                <ul class="task-list">
+                    <li> Event firehose</li>
+                    <li>Refactor of collins' caching logic, to safely support HA</li>
+                    <li>Improved LDAP authentication configuration</li>
+                    <li>Python collins client</li>
+                    <li>Consolr gem, for executing IPMI commands on collins assets</li>
+                    <li>Upgraded to play 2.3.9</li>
+                </ul>
+
+                <a href="https://github.com/tumblr/collins/releases/tag/v2.0.0">This changelog</a> contains a complete list of changes.
+            </p>
+            </li>
 	  <li>2014/09/10 - <a href="releases/collins-1.3.0.zip">1.3.0</a></li>
 	    <p>
 	      Moved to Play 2.0.8<br>


### PR DESCRIPTION
Should be merged after #467 and release is cut.