### PR TITLE
Add documentation for requireVlanName parameter

### DIFF
--- a/_data/configuration.yml
+++ b/_data/configuration.yml
@@ -20,6 +20,8 @@ sections:
     content: configuration/ipam.html
   ipmi:
     content: configuration/ipmi.html
+  lldp:
+    content: configuration/lldp.html
   monitoring:
     content: configuration/monitoring.html
   multicollins:

--- a/_includes/configuration/lldp.html
+++ b/_includes/configuration/lldp.html
@@ -1,0 +1,31 @@
+<p class="lead">Configuration for importing LLDP data</p>
+<p>
+<span class="label label-info">Namespace</span> <span class="inlinecode">lldp</span>
+</p>
+
+<p>
+Collins accepts XML output from <span class="inlinecode">lldpctl</span> in order
+to store data about which switch an asset is connected to.
+</p>
+
+<table class="table table-condensed table-hover">
+  <thead>
+    <tr>
+      <th>Key</th><th>Type</th><th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="inlinecode">requireVlanName</td>
+      <td>Boolean</td>
+      <td>If true, throw an error if the LLDP data submitted does not contain a
+      VLAN name. Defaults to true.</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="example reference-config">
+<pre>lldp {
+     requireVlanName = true
+}</pre>
+</div>


### PR DESCRIPTION
There is a `requireVlanName` parameter in the `lldp` namespace that allows LLDP imports where the VLAN name isn't set (this is the case for some Arista switches for instance). It's not documented anywhere else than the reference configs though, so this PR adds a quick section about it. See #466 as well.

@tumblr/collins @byxorna 