### PR TITLE
Collins no longer supports java 1.6

### DIFF
--- a/_includes/index/quickstart.html
+++ b/_includes/index/quickstart.html
@@ -4,8 +4,8 @@
 
 <h3>Software Requirements</h3>
 <p>
-  Collins has one software requirement - Java 1.6 (with the <a href="http://www.oracle.com/technetwork/java/javase/downloads/jce-6-download-429243.html">unlimited strength JCE</a>).
-  Collins is developed using Java 1.6 and 1.7, and we currently release builds in Java 1.6 bytecode. <br>
+  Collins has one software requirement - Java 1.7 (with the <a href="https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html">unlimited strength JCE</a>).
+  Collins is developed using Java 1.7 and 1.8, and we currently release builds in Java 1.7 bytecode. <br>
   If you would like your data to persist between restarts, you should also have MySQL 5.5 (5.1 may work but is untested).
 </p>
 


### PR DESCRIPTION
I tried to build with 1.6, and we are relying upon java.nio.file.Path which was
introduced in 1.7

@tumblr/collins 