### PR TITLE
Ensure that we build only with java 1.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
     unzip -q ./activator.zip && \
     cd collins && \
     java -version 2>&1 && \
-    PLAY_CMD=/build/activator-$ACTIVATOR_VERSION-minimal/activator ./scripts/package.sh && \
+    PLAY_CMD=/build/activator-$ACTIVATOR_VERSION-minimal/activator FORCE_BUILD=true ./scripts/package.sh && \
     unzip -q /build/collins/target/collins.zip -d /opt/ && \
     cd / && rm -rf /build && \
     rm -rf /root/.ivy2 && \
@@ -33,4 +33,3 @@ COPY conf/docker conf/
 # expose HTTP, JMX
 EXPOSE 9000 3333
 CMD ["/usr/bin/java","-server","-Dconfig.file=/opt/collins/conf/production.conf","-Dhttp.port=9000","-Dlogger.file=/opt/collins/conf/logger.xml","-Dnetworkaddress.cache.ttl=1","-Dnetworkaddress.cache.negative.ttl=1","-Dcom.sun.management.jmxremote","-Dcom.sun.management.jmxremote.port=3333","-Dcom.sun.management.jmxremote.authenticate=false","-Dcom.sun.management.jmxremote.ssl=false","-XX:MaxPermSize=384m","-XX:+CMSClassUnloadingEnabled","-XX:-UsePerfData","-cp","/opt/collins/lib/*","play.core.server.NettyServer","/opt/collins"]
-

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -18,6 +18,13 @@ if [ ! -f $PLAY_CMD ]; then
   exit 1
 fi
 
+java_version=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+echo "Building using java version $java_version"
+if [[ ! "$java_version" =~ "1.7" ]] && [[ ! $FORCE_BUILD == "true" ]]; then
+    echo "Collins should only be built with java version 1.7.  If you really know what you are doing, set the FORCE_BUILD enviornment variable to 'true'"
+    exit 1
+fi
+
 if [ $DEBUG -eq 0 ]; then
   rm -rf target/universal
   $PLAY_CMD clean compile stage


### PR DESCRIPTION
Every time I release collins, I build it with the wrong version of java.

I'm updating the package.sh script to require that you build with 1.7, just so I don't keep making this mistake on releases.

@tumblr/collins 