### PR TITLE
Return NODECLASS in API

### DIFF
--- a/app/collins/models/asset/AllAttributes.scala
+++ b/app/collins/models/asset/AllAttributes.scala
@@ -73,6 +73,7 @@ case class AllAttributes(
   def toJsValue(): JsValue = {
     val outSeq = Seq(
       "ASSET" -> asset.toJsValue,
+      "CLASSIFICATION" -> Json.toJson(asset.nodeClass),
       "HARDWARE" -> lshw.toJsValue,
       "LLDP" -> lldp.toJsValue,
       "IPMI" -> Json.toJson(ipmi),


### PR DESCRIPTION
Hi,

the API doesn't return the nodeclass right now but I want to use that to determine different partition schemes in my installer. I think this isn't a uncommon use case. What do you think?
