### PR TITLE
Write encrypted tags permission

### DIFF
--- a/app/collins/controllers/Permissions.scala
+++ b/app/collins/controllers/Permissions.scala
@@ -27,6 +27,7 @@ object Permissions {
   object Feature extends PermSpec("feature") {
     def CanSeePasswords = spec("canSeePasswords", AdminSpec)
     def CanSeeEncryptedTags = spec("canSeeEncryptedTags", AdminSpec)
+    def CanWriteEncryptedTags = spec("canWriteEncryptedTags", AdminSpec)
     def NoRateLimit = spec("noRateLimit", AdminSpec)
   }
 

--- a/app/collins/controllers/Permissions.scala
+++ b/app/collins/controllers/Permissions.scala
@@ -26,6 +26,7 @@ object Permissions {
 
   object Feature extends PermSpec("feature") {
     def CanSeePasswords = spec("canSeePasswords", AdminSpec)
+    def CanSeeEncryptedTags = spec("canSeeEncryptedTags", AdminSpec)
     def NoRateLimit = spec("noRateLimit", AdminSpec)
   }
 

--- a/app/collins/controllers/actions/AssetAction.scala
+++ b/app/collins/controllers/actions/AssetAction.scala
@@ -86,7 +86,7 @@ trait AssetResultsAction {
   protected def handleApiSuccess(p: Page[AssetView], details: Boolean): Result = {
     val items = p.items.map {
       case a: Asset => if (details){
-        a.getAllAttributes.exposeCredentials(user.canSeePasswords).toJsValue
+        a.getAllAttributes.exposeCredentials(user.canSeeEncryptedTags).toJsValue
       } else {
         a.toJsValue
       }

--- a/app/collins/controllers/actions/asset/GetAction.scala
+++ b/app/collins/controllers/actions/asset/GetAction.scala
@@ -68,7 +68,7 @@ case class GetAction(
   }
 
   protected def handleSuccess(asset: Asset): Result = {
-    val display = asset.getAllAttributes.exposeCredentials(user.canSeePasswords)
+    val display = asset.getAllAttributes.exposeCredentials(user.canSeeEncryptedTags)
     isHtml match {
       case true =>
         Status.Ok(html.asset.show(display, user)(flash, request))
@@ -78,4 +78,3 @@ case class GetAction(
   }
 
 }
-

--- a/app/collins/models/User.scala
+++ b/app/collins/models/User.scala
@@ -20,7 +20,24 @@ abstract class User(val username: String, val password: String) {
     case false => None
   }
   def isEmpty(): Boolean = username.isEmpty && password.isEmpty && roles.isEmpty
-  def canSeePasswords(): Boolean = Permissions.please(this, Permissions.Feature.CanSeePasswords)
+  def canSeeEncryptedTags(): Boolean = {
+    // We want to rename canSeePasswords to canSeeEncryptedTags
+    // but want to keep backwards compatibility
+    // Try to use canSeePasswords if it is set, else fall back to canSeePasswords
+    //
+    // All permissions default to true, so we need to test if the permission is configured,
+    // and only use it if it is.
+    val canSeePasswords = AuthenticationProvider.permissions("feature.canSeePasswords") match {
+      case None => false
+      case _ => Permissions.please(this, Permissions.Feature.CanSeePasswords)
+    }
+    val canSeeEncryptedTags = AuthenticationProvider.permissions("feature.canSeeEncryptedTags") match {
+      case None => false
+      case _ => Permissions.please(this, Permissions.Feature.CanSeeEncryptedTags)
+    }
+    canSeeEncryptedTags || canSeePasswords
+  }
+
   def isAdmin(): Boolean = hasRole("infra")
   def toMap(): Map[String, String] = Map(
     User.ID -> id().toString(),

--- a/app/collins/models/User.scala
+++ b/app/collins/models/User.scala
@@ -37,6 +37,12 @@ abstract class User(val username: String, val password: String) {
     }
     canSeeEncryptedTags || canSeePasswords
   }
+  def canWriteEncryptedTags(): Boolean = {
+    AuthenticationProvider.permissions("feature.canWriteEncryptedTags") match {
+      case None => false
+      case _ => Permissions.please(this, Permissions.Feature.CanWriteEncryptedTags)
+    }
+  }
 
   def isAdmin(): Boolean = hasRole("infra")
   def toMap(): Map[String, String] = Map(

--- a/app/views/asset/show_overview.scala.html
+++ b/app/views/asset/show_overview.scala.html
@@ -100,7 +100,7 @@
             mv.getName match {
               case "CANCEL_TICKET" => optionDisplay(0, SoftLayerHelper.ticketLink(mv.getValue), mv.getValue)
               case "DISK_STORAGE_TOTAL" => optionDisplay(1, Some(mv.getValue), mv.getValue)
-              case encrypted if Feature.encryptedTags.contains(encrypted) => if(user.canSeePasswords) { TagDecorator.decorate(mv) } else { "********" }
+              case encrypted if Feature.encryptedTags.contains(encrypted) => if(user.canSeeEncryptedTags) { TagDecorator.decorate(mv) } else { "********" }
               case _ => TagDecorator.decorate(mv)
             }
           }
@@ -196,7 +196,7 @@
           <td>Hyperthreading Enabled</td>
           <td>@{if (aa.lshw.hasHyperthreadingEnabled) "Yes" else "No"}</td>
         </tr>
-  
+
         <tr>
           <th colspan="3">Memory</th>
         </tr>
@@ -220,7 +220,7 @@
           <td>Unused Memory Banks</td>
           <td>@aa.lshw.memoryBanksUnused</td>
         </tr>
-  
+
         <tr>
           <th colspan="3">Disks</th>
         </tr>
@@ -244,7 +244,7 @@
           <td>Has PCIe Flash Disk</td>
           <td>@{if (aa.lshw.hasFlashStorage) "Yes" else "No"}</td>
         </tr>
-  
+
         <tr>
           <th colspan="3">Network</th>
         </tr>
@@ -258,7 +258,7 @@
           <td>Has 10Gb Interface</td>
           <td>@{if (aa.lshw.has10GbNic) "Yes" else "No"}</td>
         </tr>
-  
+
         <tr>
           <th colspan="3">Power</th>
         </tr>

--- a/conf/authentication.conf
+++ b/conf/authentication.conf
@@ -1,6 +1,6 @@
 authentication {
 
   type = default
-  file.userfile = "conf/users.conf"
+  permissionsFile = "conf/permissions.yaml"
 
 }

--- a/conf/dev_base.conf
+++ b/conf/dev_base.conf
@@ -18,6 +18,7 @@ features {
   useWhitelistOnRepurpose = true
   keepSomeMetaOnRepurpose = [ attr1, attr2 ]
   deleteSomeMetaOnRepurpose = [ attr4, attr3 ]
+  syslogAsset = tumblrtag1
   # default values below
   #searchResultColumns = [ TAG, HOSTNAME, PRIMARY_ROLE, STATUS, CREATED, UPDATED ]
 }

--- a/conf/docker/permissions.yaml
+++ b/conf/docker/permissions.yaml
@@ -10,7 +10,7 @@ users:
 permissions:
   feature.noRateLimit:
     - "u=tools"
-  feature.canSeePasswords:
+  feature.canSeeEncryptedTags:
     - "u=admins"
     - "u=tools"
     - "g=infra"

--- a/conf/permissions.yaml
+++ b/conf/permissions.yaml
@@ -10,7 +10,7 @@ users:
 permissions:
   feature.noRateLimit:
     - "u=tools"
-  feature.canSeePasswords:
+  feature.canSeeEncryptedTags:
     - "u=admins"
     - "u=tools"
     - "g=infra"

--- a/conf/permissions.yaml
+++ b/conf/permissions.yaml
@@ -16,6 +16,8 @@ permissions:
     - "g=infra"
     - "g=ops"
     - "g=sre"
+  feature.canWriteEncryptedTags:
+    - "u=admins"
   controllers.Admin:
     - "g=infra"
     - "g=ops"


### PR DESCRIPTION
I realized while doing some work on encrypted tags that, while we restrict which users are able to read encrypted tags, we do not restrict which users can write to them.

Depending on how you have built your automation around collins, this could have very bad consequences.

For example, if you automatically make server passwords match the password set in collins, using a configuration management tool that runs regularly like puppet or chef, an attacker that could not read the password could set it to a value they know, and then gain access or elevated permissions to your server.

This PR aims to fix this vulnerability by adding a `canWriteEncryptedTags` permission, that restricts which users are able to write encrypted tags.

It also renames `canSeePasswords` to `canSeeEncryptedTags` to better reflect what the permission does - you may have reasons to encrypt non-password attributes.  It does this in a backwards compatible manner, so your existing permissions configs that use `canSeePasswords` should continue to function.

@tumblr/collins RFR

