### PR TITLE
Fix go client lib link

### DIFF
--- a/_includes/index/features.html
+++ b/_includes/index/features.html
@@ -4,7 +4,7 @@
 </p>
 <ul>
   <li>Documented, consistent REST API</li>
-  <li>Client API libraries in <a href="https://rubygems.org/gems/collins_client"<Ruby</a>, <a href="https://pypi.python.org/pypi/collins-client/0.1.1">Python</a>, and <a href="https://github.com/tumblr/go-collins">Go.
+  <li>Client API libraries in <a href="https://rubygems.org/gems/collins_client"<Ruby</a>, <a href="https://pypi.python.org/pypi/collins-client/0.1.1">Python</a>, and <a href="https://github.com/tumblr/go-collins">Go</a>.
   <li>A collins command line shell for scripting and automation</li>
   <li>A callback system for hooking into asset lifecycle events</li>
   <li>Multiple authentication backends (LDAP, files, etc)</li>


### PR DESCRIPTION
This is broken on the features page https://tumblr.github.io/collins/#features