### PR TITLE
Skip UID verification when ipmi config is missing

### DIFF
--- a/app/collins/util/config/Feature.scala
+++ b/app/collins/util/config/Feature.scala
@@ -30,6 +30,7 @@ object Feature extends Configurable {
   def encryptedTags = getStringSet("encryptedTags")
   def keepSomeMetaOnRepurpose = getStringSet("keepSomeMetaOnRepurpose", Set())
   def intakeSupported = getBoolean("intakeSupported", true)
+  def intakeIpmiOptional = getBoolean("intakeIpmiOptional", false)
   def ignoreDangerousCommands = getStringSet("ignoreDangerousCommands")
   def hideMeta = getStringSet("hideMeta")
   def noLogAssets = getStringSet("noLogAssets")

--- a/conf/reference/features_reference.conf
+++ b/conf/reference/features_reference.conf
@@ -28,6 +28,10 @@ features {
   # Whether the tumblr intake process is supported
   intakeSupported = true
 
+  # Whether the tumblr intake process may skip UID verification for assets
+  # without IPMI configuration.
+  intakeIpmiOptional = false
+
   # A list of meta attributes to hide from display
   hideMeta = []
 


### PR DESCRIPTION
This will make collins' intake process skip UID based identification when IPMI data is missing.

Let me know if you need this configurable.