### PR TITLE
Add checkbox to redirect New assets to intake

### DIFF
--- a/app/collins/controllers/actions/AssetAction.scala
+++ b/app/collins/controllers/actions/AssetAction.scala
@@ -72,14 +72,14 @@ trait AssetAction {
 trait AssetResultsAction {
   this: SecureAction =>
 
-  protected def handleSuccess(p: Page[AssetView], details: Boolean) = isHtml match {
+  protected def handleSuccess(p: Page[AssetView], details: Boolean, redirectIntake: Boolean) = isHtml match {
     case true =>
-      handleWebSuccess(p, details)
+      handleWebSuccess(p, details, redirectIntake)
     case false =>
       handleApiSuccess(p, details)
   }
 
-  protected def handleWebSuccess(p: Page[AssetView], details: Boolean): Result = {
+  protected def handleWebSuccess(p: Page[AssetView], details: Boolean, redirectIntake: Boolean): Result = {
     Api.errorResponse(NotImplementedError.toString, NotImplementedError.status().get)
   }
 

--- a/app/collins/controllers/actions/asset/AssetFinderDataHolder.scala
+++ b/app/collins/controllers/actions/asset/AssetFinderDataHolder.scala
@@ -35,7 +35,8 @@ case class AssetFinderDataHolder(
   attributes: ResolvedAttributes,
   operation: Option[String],
   details: Option[Truthy],
-  remoteLookup: Option[Truthy]
+  remoteLookup: Option[Truthy],
+  redirectIntake: Option[Truthy]
 ) extends RequestDataHolder
 
 object AssetFinderDataHolder extends MessageHelper("assetfinder") with AttributeHelper {
@@ -43,7 +44,7 @@ object AssetFinderDataHolder extends MessageHelper("assetfinder") with Attribute
 
   val Operations = Set("and","or")
 
-  type DataForm = Tuple13[
+  type DataForm = Tuple14[
     Option[String],           // tag
     Option[List[String]],     // attribute
     Option[String],           // operation
@@ -55,6 +56,7 @@ object AssetFinderDataHolder extends MessageHelper("assetfinder") with Attribute
     Option[Date],             // updatedAfter
     Option[Date],             // updatedBefore
     Option[Truthy],           // remoteLookup,
+    Option[Truthy],           // redirectIntake,
     Option[State],            // state
     Option[String]            // query
   ]
@@ -79,6 +81,7 @@ object AssetFinderDataHolder extends MessageHelper("assetfinder") with Attribute
     "updatedAfter" -> optional(date(ISO_8601_FORMAT)),
     "updatedBefore" -> optional(date(ISO_8601_FORMAT)),
     "remoteLookup" -> optional(of[Truthy]),
+    "redirectIntake" -> optional(of[Truthy]),
     "state" -> optional(of[State]),
     "query" -> optional(text)
   ))
@@ -102,7 +105,7 @@ object AssetFinderDataHolder extends MessageHelper("assetfinder") with Attribute
 
   protected def fromForm(form: DataForm, data: Map[String,Seq[String]]): AssetFinderDataHolder = {
     val (
-      tag, attributes, operation, astatus, atype, details, cafter, cbefore, uafter, ubefore, remoteLookup, state, query
+      tag, attributes, operation, astatus, atype, details, cafter, cbefore, uafter, ubefore, remoteLookup, redirectIntake, state, query
     ) = form
     val attribs = AttributeResolver(mapAttributes(attributes.filter(_.nonEmpty), AttributeMap.fromMap(data)))
     val afinder = AssetFinder(tag, astatus, atype, cafter, cbefore, uafter, ubefore, state, query)
@@ -111,7 +114,8 @@ object AssetFinderDataHolder extends MessageHelper("assetfinder") with Attribute
       attribs,
       cleanedOperation(operation),
       details,
-      remoteLookup
+      remoteLookup,
+      redirectIntake
     )
   }
 
@@ -131,6 +135,7 @@ object AssetFinderDataHolder extends MessageHelper("assetfinder") with Attribute
     case e if e.error("operation").isDefined => message("operation.invalid")
     case e if e.error("details").isDefined => rootMessage("error.truthy", "details")
     case e if e.error("remoteLookup").isDefined => rootMessage("error.truthy", "remoteLookup")
+    case e if e.error("redirectIntake").isDefined => rootMessage("error.truthy", "redirectIntake")
     case e if e.error("state").isDefined => rootMessage("asset.state.invalid")
     case e if e.error("query").isDefined => message("query.invalid")
     case n => "Unexpected error occurred"

--- a/app/collins/controllers/actions/asset/FindAction.scala
+++ b/app/collins/controllers/actions/asset/FindAction.scala
@@ -40,7 +40,7 @@ class FindAction(
 
   override def execute(rd: RequestDataHolder) = Future { rd match {
     case afdh: AssetFinderDataHolder =>
-      val AssetFinderDataHolder(af, ra, op, de, rl) = afdh
+      val AssetFinderDataHolder(af, ra, op, de, rl, ri) = afdh
       try {
         val results = if (MultiCollinsConfig.enabled && rl.map(_.isTruthy).getOrElse(false)) {
           logger.debug("Performing remote asset find")
@@ -49,7 +49,7 @@ class FindAction(
           logger.debug("Performing local asset find")
           Asset.find(pageParams, ra, af, op)
         }
-        handleSuccess(results, afdh.details.map(_.isTruthy).getOrElse(true))
+        handleSuccess(results, afdh.details.map(_.isTruthy).getOrElse(true), afdh.redirectIntake.map(_.isTruthy).getOrElse(false))
       } catch {
         case timeout: TimeoutException => {
           handleError(RequestDataHolder.error504(

--- a/app/collins/controllers/actions/asset/FindSimilarAction.scala
+++ b/app/collins/controllers/actions/asset/FindSimilarAction.scala
@@ -85,13 +85,13 @@ case class FindSimilarAction(
           assetType = AssetType.ServerNode
         )
         Logger.logger.debug(finder.status.toString)
-        handleSuccess(Asset.findSimilar(asset, page, finder, sortType.getOrElse(AssetSort.Distribution)),details.map{_.isTruthy}.getOrElse(false))
+        handleSuccess(Asset.findSimilar(asset, page, finder, sortType.getOrElse(AssetSort.Distribution)), details.map{_.isTruthy}.getOrElse(false), false)
       }
     }
   }
 
 
-  override protected def handleWebSuccess(p: Page[AssetView], details: Boolean): Result = {
+  override protected def handleWebSuccess(p: Page[AssetView], details: Boolean, redirectIntake: Boolean): Result = {
     p.size match {
       case 0 =>
         Status.Redirect(collins.app.routes.CookieApi.getAsset(assetTag)).flashing("message" -> AssetMessages.noMatch)

--- a/app/collins/controllers/actions/resources/FindAction.scala
+++ b/app/collins/controllers/actions/resources/FindAction.scala
@@ -1,6 +1,7 @@
 package collins.controllers.actions.resources
 
 import play.api.mvc.Result
+import play.api.Logger
 
 import collins.controllers.SecureController
 import collins.controllers.actions.ActionHelper
@@ -28,16 +29,15 @@ case class FindAction(
   }
 
   // WARNING - Do not change the logic around the Redirect to intake without knowing what it does
-  override protected def handleWebSuccess(p: Page[AssetView], details: Boolean): Result = {
+  override protected def handleWebSuccess(p: Page[AssetView], details: Boolean, redirectIntake: Boolean): Result = {
     p.size match {
       case 0 =>
         Redirect(collins.app.routes.Resources.index).flashing("message" -> AssetMessages.noMatch)
       case 1 =>
         val asset = p.items(0)
-        val ignores = Set("operation")
-        val rmap = requestMap.filterNot(kv => ignores.contains(kv._1))
-        // If the only thing specified was the tag, and intake is allowed, go through intake
-        if (rmap.contains("tag") && rmap.size == 1 && assetIntakeAllowed(asset).isEmpty)
+        Logger.logger.warn("redirectIntake: %b, assetIntakeAllowed: %b".format(redirectIntake, assetIntakeAllowed(asset).isEmpty))
+        // If redirectIntake is true and intake is allowed, go through intake
+        if (redirectIntake && assetIntakeAllowed(asset).isEmpty)
           Redirect(collins.app.routes.Resources.intake(asset.id, 1))
         else
           Status.Redirect(asset.remoteHost.getOrElse("") + collins.app.routes.CookieApi.getAsset(p.items(0).tag))

--- a/app/collins/util/config/Feature.scala
+++ b/app/collins/util/config/Feature.scala
@@ -30,6 +30,7 @@ object Feature extends Configurable {
   def encryptedTags = getStringSet("encryptedTags")
   def keepSomeMetaOnRepurpose = getStringSet("keepSomeMetaOnRepurpose", Set())
   def intakeSupported = getBoolean("intakeSupported", true)
+  def intakeRedirectDefault = getBoolean("intakeRedirectDefault", false)
   def ignoreDangerousCommands = getStringSet("ignoreDangerousCommands")
   def hideMeta = getStringSet("hideMeta")
   def noLogAssets = getStringSet("noLogAssets")

--- a/app/views/resources/index.scala.html
+++ b/app/views/resources/index.scala.html
@@ -3,6 +3,7 @@
 @import helper._
 @import collins.util.views.OptionSorter
 @import collins.util.config.MultiCollinsConfig
+@import collins.util.config.Feature
 @import util._
 
 @basicFormatter(asset: AssetMeta, index: Int) = {
@@ -130,10 +131,26 @@
             }
           }
 
+          @if(Feature.intakeSupported) {
+            @formFieldRow {
+              @formLabelInline("redirectIntake", "Intake Redirect")
+              @formInputInline {
+                <div class="checkbox" style="display:inline-block;">
+                  <label>
+                  <input type="checkbox" id="redirectIntake" name="redirectIntake" value="true" tabindex="511"> Intake Redirect
+                  </label>
+                </div>
+                <span class="help-inline">
+                  <i class="glyphicon glyphicon-question-sign" data-rel="tooltip" title="Redirect to intake screen if query returns single asset with status New"></i>
+                </span>
+              }
+            }
+          }
+
           @formFieldRow {
             @formLabelInline("query","CQL Query")
             @formInputInline {
-              <textarea name="query" class="form-control" rows="4" tabindex="511" title="Enter a CQL query here.  This will be AND'ed with any other search parameters you select" placeholder="CQL Query"></textarea>
+              <textarea name="query" class="form-control" rows="4" tabindex="512" title="Enter a CQL query here.  This will be AND'ed with any other search parameters you select" placeholder="CQL Query"></textarea>
             }
           }
           </div>

--- a/app/views/resources/index.scala.html
+++ b/app/views/resources/index.scala.html
@@ -137,7 +137,7 @@
               @formInputInline {
                 <div class="checkbox" style="display:inline-block;">
                   <label>
-                  <input type="checkbox" id="redirectIntake" name="redirectIntake" value="true" tabindex="511"> Intake Redirect
+                    <input type="checkbox" id="redirectIntake" name="redirectIntake" value="true" tabindex="511"@if(Feature.intakeRedirectDefault){ checked}> Intake Redirect
                   </label>
                 </div>
                 <span class="help-inline">

--- a/conf/reference/features_reference.conf
+++ b/conf/reference/features_reference.conf
@@ -28,6 +28,9 @@ features {
   # Whether the tumblr intake process is supported
   intakeSupported = true
 
+  # Whether to enable redirect to intake checkbox by default
+  intakeRedirectDefault = false
+
   # A list of meta attributes to hide from display
   hideMeta = []
 


### PR DESCRIPTION
This adds a "Intake Redirect" checkbox on the index page. When checked
and the search returns a single asset with status New, the browser get
redirected to the intake process.

This replaces the old behavior where a search for only the tag always
redirects to intake process if the asset is New.

--
Closes #454 
Related: #484

/cc @byxorna @Primer42 Would that work for you? This would mean a minor change in your workflow: Instead if just scanning the tag to get to the intake process, you would initially set the checkbox once. If you just click return, the checkbox should stay checked. If you reload, it will get unchecked. But I can look into storing the checkbox state in the browser somehow if you think this is needed.
See also discussion in #454 