### PR TITLE
Allow skipping chassis tag verification

### DIFF
--- a/app/collins/controllers/validators/ParamValidation.scala
+++ b/app/collins/controllers/validators/ParamValidation.scala
@@ -3,6 +3,7 @@ package collins.controllers.validators
 import play.api.data.Forms.optional
 import play.api.data.Forms.text
 
+import collins.util.config.Feature
 import collins.validation.StringUtil
 
 trait ParamValidation {
@@ -15,4 +16,18 @@ trait ParamValidation {
   protected def validatedOptionalText(minLen: Int, maxLen: Int = Int.MaxValue) = optional(
     validatedText(minLen, maxLen)
   )
+  def validatedChassisTag() = optional(text().verifying { tag =>
+    tag match {
+      case null =>
+        if (Feature.intakeChassisTagOptional) {
+          true
+        } else
+          false
+      case default =>
+        validatedText(1) match {
+          case null => false
+          case default => true
+        }
+    }
+	})
 }

--- a/app/collins/util/config/Feature.scala
+++ b/app/collins/util/config/Feature.scala
@@ -30,6 +30,7 @@ object Feature extends Configurable {
   def encryptedTags = getStringSet("encryptedTags")
   def keepSomeMetaOnRepurpose = getStringSet("keepSomeMetaOnRepurpose", Set())
   def intakeSupported = getBoolean("intakeSupported", true)
+  def intakeIpmiOptional = getBoolean("intakeIpmiOptional", false)
   def ignoreDangerousCommands = getStringSet("ignoreDangerousCommands")
   def hideMeta = getStringSet("hideMeta")
   def noLogAssets = getStringSet("noLogAssets")

--- a/app/collins/util/config/Feature.scala
+++ b/app/collins/util/config/Feature.scala
@@ -31,6 +31,7 @@ object Feature extends Configurable {
   def keepSomeMetaOnRepurpose = getStringSet("keepSomeMetaOnRepurpose", Set())
   def intakeSupported = getBoolean("intakeSupported", true)
   def intakeIpmiOptional = getBoolean("intakeIpmiOptional", false)
+  def intakeChassisTagOptional = getBoolean("intakeChassisTagOptional", false)
   def ignoreDangerousCommands = getStringSet("ignoreDangerousCommands")
   def hideMeta = getStringSet("hideMeta")
   def noLogAssets = getStringSet("noLogAssets")

--- a/app/views/resources/intake3.scala.html
+++ b/app/views/resources/intake3.scala.html
@@ -2,6 +2,7 @@
 
 @import twitterBootstrap._
 @import helper._
+@import collins.util.config.Feature
 @import collins.util.views.ListHelper.getPowerComponentsInOrder
 @import util._
 @import AssetMeta.Enum.{ChassisTag, RackPosition, ServiceTag}
@@ -50,8 +51,7 @@
       @f.forField(ChassisTag.toString) { field =>
         @formLabelInline(field.name, "Chassis Tag")
         @formInputInline {
-          <input disabled id="@field.name" class="form-control" placeholder="@field.value.getOrElse("")">
-          <input type="hidden" name="@field.name" value="@field.value.getOrElse("")">
+          <input @if(!Feature.intakeChassisTagOptional){disabled} id="@ChassisTag.toString" name="@ChassisTag.toString" class="form-control" value="@field.value.getOrElse("")">
         }
       }
     }

--- a/conf/reference/features_reference.conf
+++ b/conf/reference/features_reference.conf
@@ -28,6 +28,10 @@ features {
   # Whether the tumblr intake process is supported
   intakeSupported = true
 
+  # Whether the tumblr intake process may skip UID verification for assets
+  # without IPMI configuration.
+  intakeIpmiOptional = false
+
   # A list of meta attributes to hide from display
   hideMeta = []
 

--- a/conf/reference/features_reference.conf
+++ b/conf/reference/features_reference.conf
@@ -32,6 +32,10 @@ features {
   # without IPMI configuration.
   intakeIpmiOptional = false
 
+  # Whether the intake process may skip chassis tag verification for assets
+  # without chassis tag
+  intakeChassisTagOptional = false
+
   # A list of meta attributes to hide from display
   hideMeta = []
 


### PR DESCRIPTION
With the feature intakeChassisTagOptional enabled, collins will skip the
chassis tag verification in the intake process if the chassis tag isn't
set. It will allow adding the asset tag in the final intake step.

This is based on top of #492