### PR TITLE
Only query allocated remote assets

### DIFF
--- a/app/collins/models/Asset.scala
+++ b/app/collins/models/Asset.scala
@@ -255,7 +255,7 @@ object Asset extends Schema with AnormAdapter[Asset] with AssetKeys {
   def findMulti(page: PageParams, params: AttributeResolver.ResultTuple, afinder: AssetFinder, operation: Option[String], details: Boolean): Page[AssetView] = {
     val instanceFinder = AssetFinder(
       tag = None,
-      status = None,
+      status = Status.Allocated,
       createdAfter = None,
       createdBefore = None,
       updatedAfter = None,


### PR DESCRIPTION
If you decommission an asset for multicollins, it shouldn't try to query it anymore.

I have tested this and it works as expected.

@tumblr/collins @byxorna @discordianfish 