### PR TITLE
Fix relative path to collins-client in collins-shell bin

### DIFF
--- a/support/ruby/collins-shell/bin/collins-shell
+++ b/support/ruby/collins-shell/bin/collins-shell
@@ -11,7 +11,7 @@ end
 
 $:.unshift File.join File.dirname(__FILE__), *%w[.. lib]
 # Allows us to use a dev version of collins-client if needed
-$:.unshift File.join File.dirname(__FILE__), *%w[.. .. ruby collins-client lib]
+$:.unshift File.join File.dirname(__FILE__), *%w[.. .. collins-client lib]
 %w[collins_shell collins_shell/cli].each {|f| require f}
 
 begin


### PR DESCRIPTION
This was broken in commit 27a81210cf2a8affb4a2c489a53b696bec18f13c.