### PR TITLE
Delete single ip address

### DIFF
--- a/app/collins/controllers/actions/ipaddress/DeleteAction.scala
+++ b/app/collins/controllers/actions/ipaddress/DeleteAction.scala
@@ -49,7 +49,10 @@ case class DeleteAction(
           case Some(ip: String) => IpAddresses.deleteByAssetAndAddress(asset, ip)
           case None => IpAddresses.deleteByAssetAndPool(asset, pool)
         }
-        tattler.notice("Deleted %d IP addresses".format(deleted), asset)
+        address match {
+          case Some(ip: String) if deleted > 0 => tattler.notice("Deleted IP address %s".format(address), asset)
+          case _ => tattler.notice("Deleted %d IP addresses".format(deleted), asset)
+        }
         ResponseData(Status.Ok, JsObject(Seq("DELETED" -> JsNumber(deleted))))
     }
   }

--- a/app/collins/models/IpAddresses.scala
+++ b/app/collins/models/IpAddresses.scala
@@ -108,6 +108,12 @@ object IpAddresses extends IpAddressStorage[IpAddresses] with IpAddressKeys[IpAd
     res
   }
 
+  def deleteByAssetAndAddress(asset: Asset, address: String): Int = inTransaction {
+    val addressAsLong = IpAddress.toLong(address)
+    val res = tableDef.deleteWhere(i => i.assetId === asset.id and i.address === addressAsLong)
+    res
+  }
+
   def findAssetsByAddress(page: PageParams, addys: Seq[String], finder: AssetFinder): Page[AssetView] = {
     def whereClause(assetRow: Asset, addressRow: IpAddresses) = {
       where(


### PR DESCRIPTION
As discussed in #389, this adds support for deleting a single IP address via the api.  Support is also added to `collins-shell` and `collins-client` for the newly added api call.  I was looking to add the new `address` parameter to the API docs too but it looks like that only lives in the `gh-pages` branch so that will require a separate PR.