### PR TITLE
Add ipmitool to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ VOLUME /opt/collins/conf/solr/cores/collins/data
 
 COPY . /build/collins
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y openjdk-8-jdk zip unzip && \
+    apt-get install --no-install-recommends -y openjdk-8-jdk zip unzip ipmitool && \
     rm -r /var/lib/apt/lists/* && \
     cd /build && \
     export ACTIVATOR_VERSION=1.3.7 && \


### PR DESCRIPTION
ipmitool tool is needed for the web ui intake process which is enabled by default. I believe it makes sense to have it installed here and also I am trying to setup everything without breaking away from the custom docker image you provide. 