### PR TITLE
Add EXTRA_OPTS for extra java options which do not fit other types

### DIFF
--- a/contrib/upstart/collins_env.sh
+++ b/contrib/upstart/collins_env.sh
@@ -9,4 +9,5 @@ GC_LOG_OPTS="-XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -
 GC_LOG="-Xloggc:/var/log/$APP_NAME/gc.log"
 HEAP_OPTS="-XX:MaxPermSize=384m"
 DEBUG_OPTS="-XX:ErrorFile=/var/log/$APP_NAME/java_error%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/collinsDump.hprof"
-JAVA_OPTS="-server $APP_OPTS $DNS_OPTS $JMX_OPTS $GC_OPTS $GC_LOG_OPTS $GC_LOG $HEAP_OPTS $DEBUG_OPTS"
+EXTRA_OPTS=""
+JAVA_OPTS="-server $APP_OPTS $DNS_OPTS $JMX_OPTS $GC_OPTS $GC_LOG_OPTS $GC_LOG $HEAP_OPTS $DEBUG_OPTS $EXTRA_OPTS"

--- a/scripts/collins.sh
+++ b/scripts/collins.sh
@@ -30,20 +30,21 @@ GC_LOGGING_OPTS="-XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStam
 GC_LOG="-Xloggc:${LOG_HOME}/$APP_NAME/gc.log -XX:+UseGCLogFileRotation"
 JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
 DEBUG_OPTS="-XX:ErrorFile=${LOG_HOME}/$APP_NAME/java_error%p.log -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/collinsDump.hprof"
+EXTRA_OPTS=""
 
 # Check for config overrides
 [ -f /etc/sysconfig/collins ] && . /etc/sysconfig/collins
 
 APP_OPTS="-Dconfig.file=$APP_HOME/conf/production.conf -Dhttp.port=${LISTEN_PORT} -Dlogger.file=$APP_HOME/conf/logger.xml"
 DNS_OPTS="-Dnetworkaddress.cache.ttl=1 -Dnetworkaddress.cache.negative.ttl=1"
-JAVA_OPTS="-server $APP_OPTS $DNS_OPTS $JMX_OPTS $PERMGEN_OPTS $GC_LOGGING_OPTS $GC_LOG $HEAP_OPTS $DEBUG_OPTS"
+JAVA_OPTS="-server $APP_OPTS $DNS_OPTS $JMX_OPTS $PERMGEN_OPTS $GC_LOGGING_OPTS $GC_LOG $HEAP_OPTS $DEBUG_OPTS $EXTRA_OPTS"
 
 PID_DIRECTORY="/var/run/$APP_NAME"
 pidfile="$PID_DIRECTORY/$APP_NAME.pid"
 
-# Ensures the PID_DIRECTORY exists in order to survive hard reboots. 
+# Ensures the PID_DIRECTORY exists in order to survive hard reboots.
 if [[ ! -d $PID_DIRECTORY ]] ; then
-  mkdir -p $PID_DIRECTORY 
+  mkdir -p $PID_DIRECTORY
 fi
 
 function running() {


### PR DESCRIPTION
Hi,

Due to an internal Tumblr project we are in need of adding extra flexibility to the init script. The sysconfig configuration file is handled by the users, starting with a very basic default. The need here is to allow certain java command line options which may not fit the categories otherwise specified. Most are very specific. APP_OPTS the most generic comes after sourcing of the sysconfig file so there's no much wiggle room.

@defect @roymarantz @qx-xp @komapa @byxorna @gtorre 

Thanks a bunch,

Vincent