### PR TITLE
make vlan-id attribute optional in lldp

### DIFF
--- a/app/collins/util/config/LldpConfig.scala
+++ b/app/collins/util/config/LldpConfig.scala
@@ -5,8 +5,10 @@ object LldpConfig extends Configurable {
   override val referenceConfigFilename = "lldp_reference.conf"
 
   def requireVlanName = getBoolean("requireVlanName", true)
+  def requireVlanId = getBoolean("requireVlanId", false)
 
   override protected def validateConfig() {
     requireVlanName
+    requireVlanId
   }
 }

--- a/app/collins/util/parsers/LldpParser.scala
+++ b/app/collins/util/parsers/LldpParser.scala
@@ -68,13 +68,13 @@ class LldpParser(txt: String) extends CommonParser[LldpRepresentation](txt) {
 
   protected def findVlans(seq: NodeSeq): Seq[Vlan] = {
     (seq \\ "vlan").foldLeft(Seq[Vlan]()) {
+      // some switches don't report a vlan-id, despite a VLAN being configured
+      // on an interface. Lets be flexible here and allow it to be empty.
       case (vseq, vlan) =>
-        val id = Option(vlan \ "@vlan-id" text).filter(_.nonEmpty).getOrElse("")
+        val id = Option(vlan \ "@vlan-id" text).filter(_.nonEmpty).getOrElse("0")
         val name = vlan.text
         if (LldpConfig.requireVlanName) {
-          requireNonEmpty((id -> "vlan-id"), (name -> "vlan name"))
-        } else {
-          requireNonEmpty((id -> "vlan-id"))
+          requireNonEmpty((name -> "vlan name"))
         }
         Vlan(id.toInt, name) +: vseq
     }

--- a/app/collins/util/parsers/LldpParser.scala
+++ b/app/collins/util/parsers/LldpParser.scala
@@ -71,12 +71,16 @@ class LldpParser(txt: String) extends CommonParser[LldpRepresentation](txt) {
       // some switches don't report a vlan-id, despite a VLAN being configured
       // on an interface. Lets be flexible here and allow it to be empty.
       case (vseq, vlan) =>
-        val id = Option(vlan \ "@vlan-id" text).filter(_.nonEmpty).getOrElse("0")
+        val idOpt = Option(vlan \ "@vlan-id" text)
         val name = vlan.text
         if (LldpConfig.requireVlanName) {
           requireNonEmpty((name -> "vlan name"))
         }
-        Vlan(id.toInt, name) +: vseq
+        if (LldpConfig.requireVlanId) {
+          requireNonEmpty((idOpt.getOrElse("") -> "vlan id"))
+        }
+        val id = idOpt.map(_.toInt).getOrElse(0)
+        Vlan(id, name) +: vseq
     }
   }
 

--- a/app/collins/util/parsers/LldpParser.scala
+++ b/app/collins/util/parsers/LldpParser.scala
@@ -71,7 +71,7 @@ class LldpParser(txt: String) extends CommonParser[LldpRepresentation](txt) {
       // some switches don't report a vlan-id, despite a VLAN being configured
       // on an interface. Lets be flexible here and allow it to be empty.
       case (vseq, vlan) =>
-        val idOpt = Option(vlan \ "@vlan-id" text)
+        val idOpt = Option(vlan \ "@vlan-id" text).filter(_.nonEmpty)
         val name = vlan.text
         if (LldpConfig.requireVlanName) {
           requireNonEmpty((name -> "vlan name"))

--- a/conf/reference/lldp_reference.conf
+++ b/conf/reference/lldp_reference.conf
@@ -2,4 +2,7 @@ lldp {
      # Refuse to accept lldp information with no name (aka
      # description)
      requireVlanName = true
+     # allow VLANs to omit vlan-id, to support odd devices and layer 2
+     # deployments
+     requireVlanId = false
 }

--- a/test/collins/util/parsers/LldpParserSpec.scala
+++ b/test/collins/util/parsers/LldpParserSpec.scala
@@ -58,7 +58,7 @@ class LldpParserSpec extends mutable.Specification {
       }
     }
 
-    "missing vlan-id ok" in new LldpParserHelper("lldpctl-no-vlan-id.xml"){
+    "missing vlan-id ok when !lldp.requireVlanId" in new LldpParserHelper("lldpctl-no-vlan-id.xml", Map("lldp.requireVlanId" -> "false")){
       val parseResult = parsed()
       parseResult must beRight
       parseResult.right.toOption must beSome.which { rep =>
@@ -66,6 +66,10 @@ class LldpParserSpec extends mutable.Specification {
         rep.vlanNames.toSet mustEqual (Set("fake"))
         rep.vlanIds.toSet mustEqual (Set(0))
       }
+    }
+    "missing vlan-id not ok when lldp.requireVlanId" in new LldpParserHelper("lldpctl-no-vlan-id.xml", Map("lldp.requireVlanId" -> "true")){
+      val parseResult = parsed()
+      parseResult must beLeft
     }
 
 

--- a/test/collins/util/parsers/LldpParserSpec.scala
+++ b/test/collins/util/parsers/LldpParserSpec.scala
@@ -90,7 +90,7 @@ class LldpParserSpec extends mutable.Specification {
     }
 
     "Parse XML with optional fields" in {
-      "Missing vlan-id" in new LldpParserHelper("lldpctl-bad.xml") {
+      "Missing vlan-id" in new LldpParserHelper("lldpctl-bad.xml", Map("lldp.requireVlanId" -> "false")) {
         // missing vlan-id is acceptable, for compatibility with odd switches that
         // do not report a vlan-id despite being configured
         val invalidXml = getResource(filename)

--- a/test/resources/lldpctl-no-vlan-id.xml
+++ b/test/resources/lldpctl-no-vlan-id.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lldp label="LLDP neighbors">
+ <interface label="Interface" name="eth0" via="LLDP" rid="1" age="0 day, 00:11:06">
+  <chassis label="Chassis">
+   <id label="ChassisID" type="mac">???</id>
+   <name label="SysName">system name</name>
+   <descr label="SysDescr">system desc</descr>
+   <capability label="Capability" type="Bridge" enabled="on"/>
+   <capability label="Capability" type="Router" enabled="on"/>
+  </chassis>
+  <port label="Port">
+   <id label="PortID" type="local">Port ID here</id>
+   <descr label="PortDescr">Port Description Here</descr>
+   <mfs label="MFS">1514</mfs>
+   <auto-negotiation label="PMD autoneg" supported="yes" enabled="yes">
+    <advertised label="Adv" type="40000Base-T" hd="yes" fd="yes"/>
+    <current label="MAU oper type">unknown</current>
+   </auto-negotiation>
+  </port>
+  <vlan label="VLAN" pvid="yes">fake</vlan>
+  <lldp-med label="LLDP-MED">
+   <device-type label="Device Type">Network Connectivity Device</device-type>
+   <capability label="Capability" type="Capabilities"/>
+   <capability label="Capability" type="Policy"/>
+   <capability label="Capability" type="Location"/>
+   <capability label="Capability" type="MDI/PSE"/>
+  </lldp-med>
+ </interface>
+</lldp>


### PR DESCRIPTION
Fixes #466

This codifies the behavior of some odd switches (some variants of Arista) where the `vlan-id` attribute does not get set in `lldpctl` output, despite the interface definitely being configured with a VLAN. Support this case and don't reject an lldp report just because the asset is in a topology collins doesnt like. 

@michaeljs1990 this is an upstream fix for the hacks we have in Genesis to post-process the LLDP report to fix malformed reports at induction time.

@roymarantz @michaeljs1990 @qx-xp @gtorre @defect 