### PR TITLE
Order metadata by groupId

### DIFF
--- a/app/collins/models/LshwHelper.scala
+++ b/app/collins/models/LshwHelper.scala
@@ -12,6 +12,8 @@ import collins.util.BitStorageUnit
 import collins.util.ByteStorageUnit
 import collins.util.LshwRepresentation
 
+import scala.collection.immutable.SortedMap 
+
 object LshwHelper extends CommonHelper[LshwRepresentation] {
 
   // TODO: Is this set actually used anywhere?
@@ -43,7 +45,7 @@ object LshwHelper extends CommonHelper[LshwRepresentation] {
   }
 
   def reconstruct(asset: Asset, assetMeta: Seq[MetaWrapper]): Reconstruction = {
-    val metaMap = assetMeta.groupBy { _.getGroupId }
+    val metaMap = SortedMap(assetMeta.groupBy { _.getGroupId }.toSeq.sortBy(_._1): _*)
     val (cpus,postCpuMap) = reconstructCpu(metaMap)
     val (memory,postMemoryMap) = reconstructMemory(postCpuMap)
     val (nics,postNicMap) = reconstructNics(postMemoryMap)


### PR DESCRIPTION
This orders metadata by the groupId of that metadata before passing it
onto other functions for processing. Since a Map was previously used you
could end up with your data being rendered in any which order. Now data
provided you map it correctly in the following functions will be displayed
in the proper order.

Report: https://github.com/tumblr/collins/issues/534