### PR TITLE
Add Classification to asset API

### DIFF
--- a/app/collins/models/asset/AllAttributes.scala
+++ b/app/collins/models/asset/AllAttributes.scala
@@ -74,6 +74,7 @@ case class AllAttributes(
     val outSeq = Seq(
       "ASSET" -> asset.toJsValue,
       "HARDWARE" -> lshw.toJsValue,
+      "CLASSIFICATION" -> Json.toJson(asset.nodeClass), 
       "LLDP" -> lldp.toJsValue,
       "IPMI" -> Json.toJson(ipmi),
       "ADDRESSES" -> Json.toJson(addresses),

--- a/test/collins/controllers/AssetApiSpec.scala
+++ b/test/collins/controllers/AssetApiSpec.scala
@@ -4,6 +4,7 @@ import org.specs2.mutable
 
 import play.api.libs.json.JsString
 import play.api.libs.json.Json
+import play.api.mvc.AnyContentAsFormUrlEncoded
 import play.api.test.FakeApplication
 import play.api.test.WithApplication
 
@@ -32,7 +33,7 @@ class AssetApiSpec extends mutable.Specification with ControllerSpec with Resour
         additionalConfiguration = Map(
           "solr.enabled" -> false))) with AssetApiHelper {
         override val assetTag = "B0001"
-        val request = FakeRequest("GET", "/api/asset/")
+        val request = FakeRequest("PUT", assetUrl)
         Extract.from(api.createAsset("").apply(request)) must haveStatus(400)
       }
 
@@ -44,6 +45,80 @@ class AssetApiSpec extends mutable.Specification with ControllerSpec with Resour
         Extract.from(api.updateAsset("^*$lkas$").apply(request)) must haveStatus(400)
       }
     }
+
+    "Supports Node Classifier in API" in {
+      "create a configuration asset and check that an asset matches" in new WithApplication(FakeApplication(
+        additionalConfiguration = Map(
+          "solr.enabled" -> false))) with AssetApiHelper {
+        override val assetTag = "node_classy"
+        override def assetUrl = "/api/asset/%s".format(assetTag)
+        val req = FakeRequest("PUT", assetUrl + "?type=CONFIGURATION")
+        val result = Extract.from(api.createAsset(assetTag).apply(req))
+
+        result must haveStatus(201)
+        result must haveJsonData.which { s =>
+          s must /("data") */ ("ASSET") / ("TAG" -> "node_classy")
+        }
+        
+        // make asset a nodeclass configuration
+        val requestBody = AnyContentAsFormUrlEncoded(Map(
+          "attribute" -> Seq("IS_NODECLASS;true")))
+        val req_att = FakeRequest("POST", assetUrl, requestBody)
+        val result_att = Extract.from(api.updateAsset(assetTag).apply(req_att))
+ 
+        result_att must haveStatus(200)
+        result_att must haveJsonData.which { s =>
+          s must /("data") */ ("SUCCESS" -> true)
+        }
+
+        // create asset
+        var node_asset_tag = "U01234"
+        val req_node = FakeRequest("PUT", "/api/asset/" + node_asset_tag)
+        val result_node = Extract.from(api.createAsset(node_asset_tag).apply(req_node))
+
+        result_node must haveStatus(201)
+        result_node must haveJsonData.which { s =>
+          s must /("data") */ ("ASSET") / ("TAG" -> node_asset_tag)
+        }
+
+        // get all node attributes
+        val req_node_att = FakeRequest("GET", "/api/asset/" + node_asset_tag)
+        val result_node_att = Extract.from(api.getAsset(node_asset_tag).apply(req_node_att))
+
+        result_node_att must haveStatus(200)
+        result_node_att must haveJsonData.which { s =>
+          s must /("data") */ ("CLASSIFICATION") / ("TAG" -> "node_classy")
+          s must /("data") */ ("CLASSIFICATION") / ("STATUS" -> "Incomplete")
+          s must /("data") */ ("CLASSIFICATION") / ("TYPE" -> "CONFIGURATION")
+          s must /("data") */ ("CLASSIFICATION") / ("DELETED" -> null)
+        }
+
+      }
+      "Make sure nil classification is returned when no configuration is defined" in new WithApplication(FakeApplication(
+        additionalConfiguration = Map(
+          "solr.enabled" -> false))) with AssetApiHelper {
+
+        override val assetTag = "U01235"
+        val req_node = FakeRequest("PUT", "/api/asset/" + assetTag)
+        val result_node = Extract.from(api.createAsset(assetTag).apply(req_node))
+
+        result_node must haveStatus(201)
+        result_node must haveJsonData.which { s =>
+          s must /("data") */ ("ASSET") / ("TAG" -> assetTag)
+        }
+
+        // get all node attributes
+        val req_node_att = FakeRequest("GET", "/api/asset/" + assetTag)
+        val result_node_att = Extract.from(api.getAsset(assetTag).apply(req_node_att))
+
+        result_node_att must haveStatus(200)
+        result_node_att must haveJsonData.which { s =>
+          // I can't get this to work with the normal "s must" style of testing
+          Json.parse(s) \ "data" \ "CLASSIFICATION" mustEqual play.api.libs.json.JsNull
+        }
+      }
+    }
+ 
 
     "Support Multi-step intake" in {
       "Create an asset via a PUT" in new WithApplication(FakeApplication(

--- a/test/collins/controllers/AssetApiSpec.scala
+++ b/test/collins/controllers/AssetApiSpec.scala
@@ -33,7 +33,7 @@ class AssetApiSpec extends mutable.Specification with ControllerSpec with Resour
         additionalConfiguration = Map(
           "solr.enabled" -> false))) with AssetApiHelper {
         override val assetTag = "B0001"
-        val request = FakeRequest("PUT", assetUrl)
+        val request = FakeRequest("GET", "/api/asset/")
         Extract.from(api.createAsset("").apply(request)) must haveStatus(400)
       }
 


### PR DESCRIPTION
This adds support for finding what classification a nodeclass belongs to using the API.
The tests are a little bit... a lot a bit messy however they cover the two cases well I
believe.

Closes #482 
Docs #541 