### PR TITLE
improve power status reporting

### DIFF
--- a/app/collins/controllers/actions/asset/PowerStatusAction.scala
+++ b/app/collins/controllers/actions/asset/PowerStatusAction.scala
@@ -31,9 +31,12 @@ case class PowerStatusAction(
   }
   override protected def onSuccess(s: CommandResult): ResponseData = {
     logSuccessfulPowerEvent()
-    val status = s.stdout.contains("on") match {
-      case true => "on"
-      case false => "off"
+    val result = s.stdout
+    val status = "error"
+    if (result.contains("Chassis Power is on")) {
+      val status = "on"
+    } else if (result.contains("Chassis Power is off")) {
+      val status = "off"
     }
     ResponseData(Status.Ok, JsObject(Seq("MESSAGE" -> JsString(status))))
   }


### PR DESCRIPTION
@defect @qx-xp @roymarantz rfr

We need to tighten the regex for power status results. We had an incident where ipmitool was returning a string with the word "on" in the result so collins reported servers as on when they were actually unreachable via ipmi at the time.

Regex behaves as expected:

```
scala> val result = """Chassis Power is on
     |
     | SUCCESS"""
result: String =
Chassis Power is on

SUCCESS

scala> result.contains("Chassis Power is on")
res15: Boolean = true

scala> result.contains("Chassis Power is off")
res16: Boolean = false
```

consolr:
```
[gtorre@collins A:UTIL ~]$ sudo /usr/local/bin/consolr2 -t tag --status
Chassis Power is on


SUCCESS
```

ipmitool:
```
-bash-4.1$ ipmitool -H **** -U **** -P **** -I lanplus power status
Chassis Power is on
```
