### PR TITLE
Update docs with new classification json example

### DIFF
--- a/_data/api.yml
+++ b/_data/api.yml
@@ -429,6 +429,16 @@ sections:
                       }
                     ]
                   },
+                  "CLASSIFICATION": {
+                    "ID": 3,
+                    "TAG": "dell_r610",
+                    "STATE": null,
+                    "STATUS": "Incomplete",
+                    "TYPE": "CONFIGURATION",
+                    "CREATED": "2017-04-21T14:47:37",
+                    "UPDATED": "2017-04-21T14:48:08",
+                    "DELETED": null
+                  },
                   "LLDP": {
                     "INTERFACES": [
                       {


### PR DESCRIPTION
Tested it out locally made sure everything ran with `bundle exec rake serve`. I looked around to make sure no other docs need updating but this was the only place I found that looks like it would benefit from additional documentation. 