### PR TITLE
Show overview broken out by interface capacities

### DIFF
--- a/app/collins/util/LshwRepresentation.scala
+++ b/app/collins/util/LshwRepresentation.scala
@@ -91,8 +91,11 @@ case class LshwRepresentation(
   }
 
   def nicCount: Int = nics.size
+  def nicsBySpeed = nics.groupBy { _.speed }
+  // NOTE(gabe): these has*GbNic methods are deprecated. Please use nicsBySpeed instead
   def hasGbNic: Boolean = nics.find { _.speed.inGigabits == 1 }.map { _ => true }.getOrElse(false)
   def has10GbNic: Boolean = nics.find { _.speed.inGigabits == 10 }.map { _ => true }.getOrElse(false)
+
   def macAddresses: Seq[String] = nics.map { _.macAddress }
 
   def toJsValue() = Json.toJson(this)

--- a/app/collins/util/LshwRepresentation.scala
+++ b/app/collins/util/LshwRepresentation.scala
@@ -91,15 +91,15 @@ case class LshwRepresentation(
   }
 
   def nicCount: Int = nics.size
-  def nicsBySpeed = nics.groupBy { _.speed }
-  // NOTE(gabe): these has*GbNic methods are deprecated. Please use nicsBySpeed instead
-  def hasGbNic: Boolean = nics.find { _.speed.inGigabits == 1 }.map { _ => true }.getOrElse(false)
-  def has10GbNic: Boolean = nics.find { _.speed.inGigabits == 10 }.map { _ => true }.getOrElse(false)
+  def nicsBySpeedGb = nics.groupBy { _.speed.inGigabits }
 
   def macAddresses: Seq[String] = nics.map { _.macAddress }
 
   def toJsValue() = Json.toJson(this)
 
+  // TODO(gabe): this method only performs squinty eye comparison. it will
+  // falsely report 2 lshw as equal if they have the same number of 1g nics
+  // but different mac addresses. FIXME
   override def equals(that: Any) = that match {
     case other: LshwRepresentation =>
       (macAddresses.sorted == other.macAddresses.sorted) &&
@@ -117,9 +117,7 @@ case class LshwRepresentation(
         (hasFlashStorage == other.hasFlashStorage) &&
         (totalFlashStorage.inBytes == other.totalFlashStorage.inBytes) &&
         (totalUsableStorage.inBytes == other.totalUsableStorage.inBytes) &&
-        (nicCount == other.nicCount) &&
-        (hasGbNic == other.hasGbNic) &&
-        (has10GbNic == other.has10GbNic)
+        (nicCount == other.nicCount)
     case _ => false
   }
 }

--- a/app/views/asset/show_overview.scala.html
+++ b/app/views/asset/show_overview.scala.html
@@ -260,10 +260,10 @@
           <td>Total Interfaces</td>
           <td>@aa.lshw.nicCount</td>
         </tr>
-        @aa.lshw.nicsBySpeed.map { case(speed,nics) =>
+        @aa.lshw.nicsBySpeedGb.map { case(speedGb,nics) =>
         <tr>
           <td></td>
-          <td>@{speed.inGigabits}G Interfaces</td>
+          <td>@{speedGb}G Interfaces</td>
           <td>@{nics.size}</td>
         </tr>
         }

--- a/app/views/asset/show_overview.scala.html
+++ b/app/views/asset/show_overview.scala.html
@@ -257,15 +257,16 @@
         </tr>
         <tr>
           <td></td>
-          <td>Interfaces</td>
+          <td>Total Interfaces</td>
           <td>@aa.lshw.nicCount</td>
         </tr>
+        @aa.lshw.nicsBySpeed.map { case(speed,nics) =>
         <tr>
           <td></td>
-          <td>Has 10Gb Interface</td>
-          <td>@{if (aa.lshw.has10GbNic) "Yes" else "No"}</td>
+          <td>@{speed.inGigabits}G Interfaces</td>
+          <td>@{nics.size}</td>
         </tr>
-
+        }
         <tr>
           <th colspan="3">Power</th>
         </tr>

--- a/test/collins/util/parsers/LshwParserSpec.scala
+++ b/test/collins/util/parsers/LshwParserSpec.scala
@@ -43,8 +43,8 @@ class LshwParserSpec extends mutable.Specification {
           rep.diskCount mustEqual 6
 
           rep.nicCount mustEqual 3
-          rep.hasGbNic must beTrue
-          rep.has10GbNic must beTrue
+          rep.nicsBySpeedGb(1).size mustEqual 2
+          rep.nicsBySpeedGb(10).size mustEqual 1
           rep.macAddresses must have length 3
           rep.macAddresses must beNonEmptyStringSeq
 
@@ -59,8 +59,8 @@ class LshwParserSpec extends mutable.Specification {
         parseResults must beRight
         parseResults.right.toOption must beSome.which { rep =>
           rep.nicCount mustEqual 4
-          rep.hasGbNic must beTrue
-          rep.has10GbNic must beTrue
+          rep.nicsBySpeedGb(1).size mustEqual 2
+          rep.nicsBySpeedGb(10).size mustEqual 2
           rep.macAddresses must have length 4
           rep.macAddresses must beNonEmptyStringSeq
 
@@ -91,8 +91,8 @@ class LshwParserSpec extends mutable.Specification {
           rep.totalUsableStorage.toHuman mustEqual "5.46 TB"
 
           rep.nicCount mustEqual 2
-          rep.hasGbNic must beTrue
-          rep.has10GbNic must beFalse
+          rep.nicsBySpeedGb(1).size mustEqual 2
+          rep.nicsBySpeedGb get 10 must beNone
           rep.macAddresses must have length 2
           rep.macAddresses must beNonEmptyStringSeq
         }
@@ -120,8 +120,8 @@ class LshwParserSpec extends mutable.Specification {
           rep.totalUsableStorage.toHuman mustEqual "931.52 GB"
 
           rep.nicCount mustEqual 6
-          rep.hasGbNic must beTrue
-          rep.has10GbNic must beFalse
+          rep.nicsBySpeedGb(1).size mustEqual 6
+          rep.nicsBySpeedGb get 10 must beNone
           rep.macAddresses must have length 6
           rep.macAddresses must beNonEmptyStringSeq
         }
@@ -149,8 +149,9 @@ class LshwParserSpec extends mutable.Specification {
           rep.totalUsableStorage.toHuman mustEqual "931.52 GB"
 
           rep.nicCount mustEqual 6
-          rep.hasGbNic must beTrue
-          rep.has10GbNic aka "has 10 gig card" must beTrue // picked up from default in config
+          rep.nicsBySpeedGb(1).size mustEqual 5
+          // collins should assume 10g capacity for the nic that isnt reporting it
+          rep.nicsBySpeedGb(10).size mustEqual 1
           rep.macAddresses must have length 6
           rep.macAddresses must beNonEmptyStringSeq
         }
@@ -178,8 +179,8 @@ class LshwParserSpec extends mutable.Specification {
           rep.diskCount mustEqual 4
 
           rep.nicCount mustEqual 2
-          rep.hasGbNic must beTrue
-          rep.has10GbNic must beFalse
+          rep.nicsBySpeedGb(1).size mustEqual 2
+          rep.nicsBySpeedGb get 10 must beNone
           rep.macAddresses must have length 2
           rep.macAddresses must beNonEmptyStringSeq
         }
@@ -206,8 +207,8 @@ class LshwParserSpec extends mutable.Specification {
           rep.diskCount mustEqual 3
 
           rep.nicCount mustEqual 4
-          rep.hasGbNic must beTrue
-          rep.has10GbNic must beFalse
+          rep.nicsBySpeedGb(1).size mustEqual 4
+          rep.nicsBySpeedGb get 10 must beNone
           rep.macAddresses must have length 4
           rep.macAddresses must beNonEmptyStringSeq
 
@@ -234,8 +235,8 @@ class LshwParserSpec extends mutable.Specification {
           rep.diskCount mustEqual 2
 
           rep.nicCount mustEqual 6
-          rep.hasGbNic must beTrue
-          rep.has10GbNic must beFalse
+          rep.nicsBySpeedGb(1).size mustEqual 6
+          rep.nicsBySpeedGb get 10 must beNone
           rep.macAddresses must have length 6
           rep.macAddresses must beNonEmptyStringSeq
         }
@@ -259,8 +260,8 @@ class LshwParserSpec extends mutable.Specification {
           rep.diskCount mustEqual 3
 
           rep.nicCount mustEqual 4
-          rep.hasGbNic must beTrue
-          rep.has10GbNic must beFalse
+          rep.nicsBySpeedGb(1).size mustEqual 4
+          rep.nicsBySpeedGb get 10 must beNone
           rep.macAddresses must have length 4
           rep.macAddresses must beNonEmptyStringSeq
         }
@@ -287,8 +288,8 @@ class LshwParserSpec extends mutable.Specification {
           rep.hasCdRom must beFalse
 
           rep.nicCount mustEqual 2
-          rep.hasGbNic must beTrue
-          rep.has10GbNic must beFalse
+          rep.nicsBySpeedGb(1).size mustEqual 2
+          rep.nicsBySpeedGb get 10 must beNone
           rep.macAddresses must have length 2
           rep.macAddresses must beNonEmptyStringSeq
 
@@ -349,8 +350,8 @@ class LshwParserSpec extends mutable.Specification {
           rep.hasCdRom must beTrue
 
           rep.nicCount mustEqual 4
-          rep.hasGbNic must beTrue
-          rep.has10GbNic must beFalse
+          rep.nicsBySpeedGb(1).size mustEqual 4
+          rep.nicsBySpeedGb get 10 must beNone
           rep.macAddresses must have length 4
           rep.macAddresses must beNonEmptyStringSeq
         }
@@ -377,8 +378,8 @@ class LshwParserSpec extends mutable.Specification {
           rep.hasCdRom must beTrue
 
           rep.nicCount mustEqual 4
-          rep.hasGbNic must beTrue
-          rep.has10GbNic must beFalse
+          rep.nicsBySpeedGb(1).size mustEqual 4
+          rep.nicsBySpeedGb get 10 must beNone
           rep.macAddresses must have length 4
           rep.macAddresses must beNonEmptyStringSeq
         }
@@ -415,8 +416,8 @@ class LshwParserSpec extends mutable.Specification {
           rep.memoryBanksTotal mustEqual 24
 
           rep.nicCount mustEqual 4
-          rep.hasGbNic must beTrue
-          rep.has10GbNic must beFalse
+          rep.nicsBySpeedGb(1).size mustEqual 4
+          rep.nicsBySpeedGb get 10 must beNone
           rep.macAddresses must have length 4
           rep.macAddresses must beNonEmptyStringSeq
 
@@ -446,8 +447,8 @@ class LshwParserSpec extends mutable.Specification {
           rep.totalUsableStorage.toHuman mustEqual "381.94 GB"
 
           rep.nicCount mustEqual 4
-          rep.hasGbNic must beTrue
-          rep.has10GbNic must beFalse
+          rep.nicsBySpeedGb(1).size mustEqual 4
+          rep.nicsBySpeedGb get 10 must beNone
           rep.macAddresses must have length 4
           rep.macAddresses must beNonEmptyStringSeq
         }
@@ -470,8 +471,8 @@ class LshwParserSpec extends mutable.Specification {
           rep.memoryBanksTotal mustEqual 12
 
           rep.nicCount mustEqual 2
-          rep.hasGbNic must beTrue
-          rep.has10GbNic must beFalse
+          rep.nicsBySpeedGb(1).size mustEqual 2
+          rep.nicsBySpeedGb get 10 must beNone
           rep.macAddresses must have length 2
           rep.macAddresses must beNonEmptyStringSeq
 


### PR DESCRIPTION
Fixes #545

@michaeljs1990 This updates the show overview to indicate how many of each capacity interface are present. For example, if a machine has 4x1g and 1x10g interfaces, the show overview will reflect this in a terse manner. Similarly, a machine with 1x40g nic will show that it includes a 40g nic, instead of reporting it does not have a 10g.

cc @defect @roymarantz @gtorre @qx-xp 

Homogenous interfaces:
![screenshot from 2017-05-20 14-09-33](https://cloud.githubusercontent.com/assets/130194/26275648/073fc1de-3d66-11e7-9f18-cdf1af6d26ee.png)

Mixed interfaces:
![screenshot from 2017-05-20 14-19-14](https://cloud.githubusercontent.com/assets/130194/26275713/7d2399e2-3d67-11e7-800f-50d39a1d10b5.png)