### PR TITLE
Fix ipmi pool api

### DIFF
--- a/app/collins/controllers/actions/ipmi/GetPoolsAction.scala
+++ b/app/collins/controllers/actions/ipmi/GetPoolsAction.scala
@@ -26,9 +26,9 @@ case class GetPoolsAction(
 
   override def validate(): Validation = {
     var pools: Set[String] =
-      IpmiInfo.AddressConfig.filter(_.poolNames.isEmpty) match {
-        case Set => IpmiInfo.AddressConfig.map(_.poolNames).getOrElse(Set(""))
-        case _ => Set(IpmiInfo.AddressConfig.flatMap(_.defaultPoolName).getOrElse(""))
+      IpmiInfo.AddressConfig.map(_.poolNames).getOrElse(false) match {
+        case x: Set[String]  => x
+        case _               => Set(IpmiInfo.AddressConfig.flatMap(_.defaultPoolName).getOrElse(""))
       }
 
     Right(ActionDataHolder(pools))

--- a/app/collins/controllers/actions/ipmi/GetPoolsAction.scala
+++ b/app/collins/controllers/actions/ipmi/GetPoolsAction.scala
@@ -26,9 +26,9 @@ case class GetPoolsAction(
 
   override def validate(): Validation = {
     var pools: Set[String] =
-      IpmiInfo.AddressConfig.map(_.poolNames).getOrElse(false) match {
-        case x: Set[String]  => x
-        case _               => Set(IpmiInfo.AddressConfig.flatMap(_.defaultPoolName).getOrElse(""))
+      IpmiInfo.AddressConfig.map(_.poolNames) match {
+        case x if !x.isEmpty  => x.getOrElse(Set())
+        case _                => Set(IpmiInfo.AddressConfig.flatMap(_.defaultPoolName).getOrElse(""))
       }
 
     Right(ActionDataHolder(pools))

--- a/conf/test_base.conf
+++ b/conf/test_base.conf
@@ -249,6 +249,11 @@ ipmi {
       gateway="172.16.32.1"
       startAddress="172.16.32.20"
     }
+    OOB-POD02 {
+      network="172.99.32.0/20"
+      gateway="172.99.32.1"
+      startAddress="172.99.32.20"
+    }
   }
 
   # to use with multiple OOB allocations, instead of the inline

--- a/test/collins/controllers/IpmiApiSpec.scala
+++ b/test/collins/controllers/IpmiApiSpec.scala
@@ -3,7 +3,10 @@ package collins.controllers
 import collins._
 import org.specs2._
 import specification._
+import com.typesafe.config._
+import play.api.Configuration
 import play.api.test.WithApplication
+import play.api.test.FakeApplication
 import org.specs2.matcher.JsonMatchers
 
 class IpmiApiSpec extends mutable.Specification with ControllerSpec {
@@ -13,7 +16,7 @@ class IpmiApiSpec extends mutable.Specification with ControllerSpec {
   args(sequential = true)
 
   "the REST API" should {
-    "Support getting ipmi pools" in new WithApplication with AssetApiHelper {
+    "Support getting multiple ipmi pools" in new WithApplication with AssetApiHelper {
       override val assetTag = "tumblrtag42"
       val getRequest = FakeRequest("GET", "/api/ipmi/pools")
       val getResult = Extract.from(api.getIpmiAddressPools.apply(getRequest))
@@ -23,6 +26,12 @@ class IpmiApiSpec extends mutable.Specification with ControllerSpec {
         s must /("data") */("POOLS") */ ("GATEWAY" -> "172.16.32.1")
         s must /("data") */("POOLS") */ ("START_ADDRESS" -> "172.16.32.20")
         s must /("data") */("POOLS") */ ("BROADCAST" -> "172.16.47.255")
+        s must /("data") */("POOLS") */ ("POSSIBLE_ADDRESSES" -> 4094)
+
+        s must /("data") */("POOLS") */ ("NAME" -> "OOB-POD02")
+        s must /("data") */("POOLS") */ ("GATEWAY" -> "172.99.32.1")
+        s must /("data") */("POOLS") */ ("START_ADDRESS" -> "172.99.32.20")
+        s must /("data") */("POOLS") */ ("BROADCAST" -> "172.99.47.255")
         s must /("data") */("POOLS") */ ("POSSIBLE_ADDRESSES" -> 4094)
       }
     }

--- a/test/collins/controllers/IpmiApiSpec.scala
+++ b/test/collins/controllers/IpmiApiSpec.scala
@@ -3,10 +3,7 @@ package collins.controllers
 import collins._
 import org.specs2._
 import specification._
-import com.typesafe.config._
-import play.api.Configuration
 import play.api.test.WithApplication
-import play.api.test.FakeApplication
 import org.specs2.matcher.JsonMatchers
 
 class IpmiApiSpec extends mutable.Specification with ControllerSpec {


### PR DESCRIPTION
I messed this up somehow even though I checked it a ton of times. Not sure
how i missed this but I have since learned pattern matching in scala sets
is not that simple. This correctly matches against Sets and non Sets. I
updated the test to check for the case of two pools being returned since it
additionally checks for the case that one pool can be returned.

I spend far too much time trying to get different configs to work with the tests
I had some luck using FakeApplication and setting some additionalConfig for it.
However it turns out that if you have two tests using fake config and they are
both different only the first test that runs fake config takes effect and it applies
to all the other runs...