### PR TITLE
Don't show Graphs tabs if plugin is disabled

### DIFF
--- a/app/views/asset/show_menu.scala.html
+++ b/app/views/asset/show_menu.scala.html
@@ -5,7 +5,7 @@
 @import collins.util.views.{Maintenance, SoftLayerHelper, OptionSorter, ProvisionerHelper, Summary, TagDecorator, Titler}
 @import collins.provisioning.ProvisionerConfig
 @import collins.provisioning.Provisioner
-@import collins.graphs.GraphView
+@import collins.graphs.{GraphConfig, GraphView}
 @import collins.frames.{ViewsConfig, FrameView}
 @import collins.controllers.Permissions
 
@@ -71,10 +71,12 @@
 	        }
         </ul>
       </li>
-      @if(GraphView.isGraphable(aa.asset)) {
-        <li><a href="#graph-info" data-toggle="pill">Graphs</a></li>
-      } else {
-        <li class="disabled" data-rel="tooltip" data-original-title="This asset is not graphable"><a href="javascript:void(0);">Graphs</a></li>
+      @if(GraphConfig.enabled) {
+        @if(GraphView.isGraphable(aa.asset)) {
+          <li><a href="#graph-info" data-toggle="pill">Graphs</a></li>
+        } else {
+          <li class="disabled" data-rel="tooltip" data-original-title="This asset is not graphable"><a href="javascript:void(0);">Graphs</a></li>
+        }
       }
       @if(ViewsConfig.enabled) {
         @for(specs <- FrameView.getViewSpecs(aa)) {


### PR DESCRIPTION
Quite simple, if the `graph` plugin is disabled, there's not much point in showing the menu item in the asset view. If the plugin is enabled, but the asset isn't graphable, it'll still show up in the same grayed out manner as before.

Maybe the `graph` plugin should be deprecated now since we have the much more flexible `views` plugin? Not a big issue, but something to ponder.

@byxorna @roymarantz @qx-xp @gtorre 