### PR TITLE
Split dockerfile to build container and runtime container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
 .git
 _site
-target
 support
 vendor
 project/target
+project/project
+target/collins
+target/scala-2.11
+target/universal

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,14 @@
 FROM openjdk:8-jre
-MAINTAINER Gabe Conradi <gabe@tumblr.com>
 
 # Solr cores should be stored in a volume, so we arent writing stuff to our rootfs
 VOLUME /opt/collins/conf/solr/cores/collins/data
 
-COPY . /build/collins
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y openjdk-8-jdk openjdk-8-jdk-headless zip unzip ipmitool && \
-    rm -r /var/lib/apt/lists/* && \
-    cd /build && \
-    export ACTIVATOR_VERSION=1.3.7 && \
-    wget -q http://downloads.typesafe.com/typesafe-activator/$ACTIVATOR_VERSION/typesafe-activator-$ACTIVATOR_VERSION-minimal.zip -O /build/activator.zip && \
-    unzip -q ./activator.zip && \
-    cd collins && \
-    java -version 2>&1 && \
-    PLAY_CMD=/build/activator-$ACTIVATOR_VERSION-minimal/activator FORCE_BUILD=true ./scripts/package.sh && \
-    unzip -q /build/collins/target/collins.zip -d /opt/ && \
-    cd / && rm -rf /build && \
-    rm -rf /root/.ivy2 && \
-    rm -rf /root/.sbt && \
-    apt-get remove -y --purge openjdk-8-jdk openjdk-8-jdk-headless && \
-    apt-get autoremove --purge -y && \
-    apt-get clean && \
-    rm /var/log/dpkg.log
+COPY target/collins.zip /opt/collins.zip
+RUN unzip /opt/collins.zip -d /opt && rm /opt/collins.zip
 
 WORKDIR /opt/collins
+COPY conf/docker conf
 
-# Add in all the default configs we want in this build so collins can run.
-# You probably will want to override these configs in production
-COPY conf/docker conf/
-
-# expose HTTP, JMX
 EXPOSE 9000 3333
 CMD ["/usr/bin/java","-server","-Dconfig.file=/opt/collins/conf/production.conf","-Dhttp.port=9000","-Dlogger.file=/opt/collins/conf/logger.xml","-Dnetworkaddress.cache.ttl=1","-Dnetworkaddress.cache.negative.ttl=1","-Dcom.sun.management.jmxremote","-Dcom.sun.management.jmxremote.port=3333","-Dcom.sun.management.jmxremote.authenticate=false","-Dcom.sun.management.jmxremote.ssl=false","-XX:MaxPermSize=384m","-XX:+CMSClassUnloadingEnabled","-XX:-UsePerfData","-cp","/opt/collins/lib/*","play.core.server.NettyServer","/opt/collins"]
+

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,23 @@
+FROM openjdk:8-jre
+MAINTAINER Gabe Conradi <gabe@tumblr.com>
+
+ENV ACTIVATOR_VERSION=1.3.7
+ENV PLAY_CMD=/opt/activator-$ACTIVATOR_VERSION-minimal/activator
+ENV PATH=$PATH:/opt/activator-$ACTIVATOR_VERSION-minimal/
+ENV FORCE_BUILD=true
+
+WORKDIR /build
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y openjdk-8-jdk openjdk-8-jdk-headless zip unzip ipmitool && \
+    rm -r /var/lib/apt/lists/*
+
+COPY . /build
+
+RUN wget http://downloads.typesafe.com/typesafe-activator/$ACTIVATOR_VERSION/typesafe-activator-$ACTIVATOR_VERSION-minimal.zip -O /opt/activator.zip && \
+    unzip /opt/activator.zip -d /opt/ && \
+    /opt/activator-$ACTIVATOR_VERSION-minimal/activator update
+
+VOLUME /build/app
+
+CMD "./scripts/package.sh"


### PR DESCRIPTION
So, after rebuilding the container for the Nth time i started toying with the idea of breaking out the building parts of the process into it's own container since we don't really need activator/sbt/etc. to run collins once the zip has been produced.

This creates a `Dockerfile.build` which sets up the basic build toolchain and should in my mind make it easier and quicker to get started with building collins. For instance, after creating the build container we can build the zip by running
```
~/W/t/collins (split_dockerfiles) >time docker run -v $(pwd)/target:/build/target b97efa2bb6dc ./scripts/package.sh
[..]
docker run b97efa2bb6dc ./scripts/package.sh  0.03s user 0.03s system 0% cpu 1:49.67 total
```
which should be a lot quicker than building from scratch since we already have the dependencies and toolchain. If we're making a lot of changes we can have a container re-compiling on changes by running
```
~/W/t/collins (split_dockerfiles) >docker run -it -v $(pwd)/app:/build/app 5f787656d457 activator
[info] Loading project definition from /build/project
[info] Set current project to collins (in build file:/build/)
[collins] $ ~ compile
[info] Compiling 331 Scala sources and 9 Java sources to /build/target/scala-2.11/classes...
[info] 'compiler-interface' not yet compiled for Scala 2.11.7. Compiling...
[info]   Compilation completed in 13.051 s
[success] Total time: 74 s, completed Jun 27, 2017 9:46:21 PM
1. Waiting for source changes... (press enter to interrupt)
[info] Compiling 1 Scala source to /build/target/scala-2.11/classes...
[success] Total time: 5 s, completed Jun 27, 2017 9:46:43 PM
2. Waiting for source changes... (press enter to interrupt)
```

The final "runtime" container becomes a lot simpler too.


I haven't really tried all different use-cases here, but I thought I'd ask for some feedback. Does this make sense at all?

@tumblr/collins @byxorna @michaeljs1990  Thoughts?