### PR TITLE
multistage docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,45 @@
+FROM openjdk:8-jdk AS build
+MAINTAINER Gabe Conradi <gabe@tumblr.com>
+
+ENV ACTIVATOR_VERSION=1.3.7
+WORKDIR /build
+# install prereqs
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y zip unzip wget && \
+    wget -q http://downloads.typesafe.com/typesafe-activator/$ACTIVATOR_VERSION/typesafe-activator-$ACTIVATOR_VERSION-minimal.zip -O /build/activator.zip && \
+    unzip -q ./activator.zip
+
+WORKDIR /build/collins
+# install the bare minimum necessary for a scala project to install deps
+# redownload all the deps each time the source changes
+COPY ./build.sbt /build/collins/build.sbt
+COPY ./project/ /build/collins/project/
+# just download and update dependencies before we copy in source
+RUN /build/activator-$ACTIVATOR_VERSION-minimal/activator update
+
+COPY . /build/collins
+RUN PLAY_CMD=/build/activator-$ACTIVATOR_VERSION-minimal/activator FORCE_BUILD=true ./scripts/package.sh
+# install build to /opt/collins
+RUN unzip -q /build/collins/target/collins.zip -d /opt/
+
 FROM openjdk:8-jre
 MAINTAINER Gabe Conradi <gabe@tumblr.com>
 
 # Solr cores should be stored in a volume, so we arent writing stuff to our rootfs
 VOLUME /opt/collins/conf/solr/cores/collins/data
 
-COPY . /build/collins
-RUN apt-get update && \
-    apt-get install --no-install-recommends -y openjdk-8-jdk openjdk-8-jdk-headless zip unzip ipmitool && \
-    rm -r /var/lib/apt/lists/* && \
-    cd /build && \
-    export ACTIVATOR_VERSION=1.3.7 && \
-    wget -q http://downloads.typesafe.com/typesafe-activator/$ACTIVATOR_VERSION/typesafe-activator-$ACTIVATOR_VERSION-minimal.zip -O /build/activator.zip && \
-    unzip -q ./activator.zip && \
-    cd collins && \
-    java -version 2>&1 && \
-    PLAY_CMD=/build/activator-$ACTIVATOR_VERSION-minimal/activator FORCE_BUILD=true ./scripts/package.sh && \
-    unzip -q /build/collins/target/collins.zip -d /opt/ && \
-    cd / && rm -rf /build && \
-    rm -rf /root/.ivy2 && \
-    rm -rf /root/.sbt && \
-    apt-get remove -y --purge openjdk-8-jdk openjdk-8-jdk-headless && \
-    apt-get autoremove --purge -y && \
-    apt-get clean && \
-    rm /var/log/dpkg.log
-
 WORKDIR /opt/collins
 
+# copy the built artifacts from the build container into our deploy
+COPY --from=build /opt/collins/ /opt/collins/
 # Add in all the default configs we want in this build so collins can run.
 # You probably will want to override these configs in production
-COPY conf/docker conf/
+COPY conf/docker /opt/collins/conf/
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y ipmitool && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # expose HTTP, JMX
 EXPOSE 9000 3333


### PR DESCRIPTION
@roymarantz @qx-xp @gtorre @defect #561 

This is my attempt at using multistage docker builds to simplify the runtime of tumblr/collins. This produces a build that is 394MB now, as compared to the current image which is 427MB. Not a tremendous savings, but definitely is cognitively simpler to reason about. @defect feel free to pull things from this PR as you would like, if you want to modify #561. I am putting this up only for comments and as a POC; I am happy to abandon if you want to land your changes :)

```
[23:50:44] [gabe@ono-sendai-9] ( 0 ) ~/code/collins gabe-multistage-docker-build*                                                                                                                                          -> $ docker build -t tumblr/collins .                                                                        
Sending build context to Docker daemon  4.325MB       
Step 1/21 : FROM openjdk:8-jdk AS build               
 ---> 553ac881328e                                    
Step 2/21 : MAINTAINER Gabe Conradi <gabe@tumblr.com> 
 ---> Using cache                                                                                            
 ---> 1fa61f279eef                                    
Step 3/21 : ENV ACTIVATOR_VERSION 1.3.7                                                                      
 ---> Using cache                                                                                            
 ---> 0a9480665d74                                                                                           
Step 4/21 : WORKDIR /build                                                                                   
 ---> Using cache                                                                                            
 ---> 5f0ebbde9f76                                                                                           
Step 5/21 : RUN apt-get update &&     apt-get install --no-install-recommends -y zip unzip wget &&     wget -q http://downloads.typesafe.com/typesafe-activator/$ACTIVATOR_VERSION/typesafe-activator-$ACTIVATOR_VERSION-mi
nimal.zip -O /build/activator.zip &&     unzip -q ./activator.zip                                            
 ---> Using cache                                                                                            
 ---> 08de94e0c6a1                                                                                           
Step 6/21 : WORKDIR /build/collins                                                                           
 ---> Using cache                                     
 ---> 71d66bb54bc4                                    
Step 7/21 : COPY ./build.sbt /build/collins/build.sbt 
 ---> Using cache                                                                                            
 ---> 885fcdd4343a                                                                                           
Step 8/21 : COPY ./project/ /build/collins/project/   
 ---> Using cache                                     
 ---> c4fe7e66a630                                    
Step 9/21 : RUN /build/activator-$ACTIVATOR_VERSION-minimal/activator update                                 
 ---> Using cache                                                                                            
 ---> 508259f3cec1                                    
Step 10/21 : COPY . /build/collins                    
 ---> Using cache                                     
 ---> 5c84e3cc2ffd                                    
Step 11/21 : RUN PLAY_CMD=/build/activator-$ACTIVATOR_VERSION-minimal/activator FORCE_BUILD=true ./scripts/package.sh                                                                                                      
 ---> Using cache                                     
 ---> 37aa5f2dd3b1                                    
Step 12/21 : RUN unzip -q /build/collins/target/collins.zip -d /opt/                                         
 ---> Using cache                                                                                            
 ---> 62a7003dc760                                                                                           
Step 13/21 : FROM openjdk:8-jre                       
 ---> d18ae8f18728                                    
Step 14/21 : MAINTAINER Gabe Conradi <gabe@tumblr.com>
 ---> Using cache                                                                                            
 ---> 78f39a526c54                                                                                           
Step 15/21 : VOLUME /opt/collins/conf/solr/cores/collins/data                                                
 ---> Using cache                                                                                            
 ---> c08b4cce39f4                                    
Step 16/21 : WORKDIR /opt/collins                                                                            
 ---> Using cache                                     
 ---> 80fd54887d30                                    
Step 17/21 : COPY --from=build /opt/collins/ /opt/collins/                                                   
 ---> Using cache                                     
 ---> e74fb82fbe53                                    
Step 18/21 : COPY conf/docker /opt/collins/conf/      
 ---> Using cache                                     
 ---> ff5b6d208abd                                                                                           
Step 19/21 : RUN apt-get update &&     apt-get install --no-install-recommends -y ipmitool &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*                                                                         
 ---> Using cache                                                                                            
 ---> 66aa2e360320                                    
Step 20/21 : EXPOSE 9000 3333                                                                                
 ---> Using cache                                                                                            
 ---> 80176fc9d9da                                    
Step 21/21 : CMD /usr/bin/java -server -Dconfig.file=/opt/collins/conf/production.conf -Dhttp.port=9000 -Dlogger.file=/opt/collins/conf/logger.xml -Dnetworkaddress.cache.ttl=1 -Dnetworkaddress.cache.negative.ttl=1 -Dcom
.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -XX:MaxPermSize=384m -XX:+CMSClassUnloadingEnabled -XX:-UsePerfData -cp /opt/collins/lib/* play.core.server.NettyServer /opt/collins                                      
 ---> Using cache                                     
 ---> 543cf017c4f1                                    
Successfully built 543cf017c4f1                       
Successfully tagged tumblr/collins:latest             
[23:50:55] [gabe@ono-sendai-9] ( 0 ) ~/code/collins gabe-multistage-docker-build*                            
-> $ docker images                                    
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE                         
tumblr/collins      latest              543cf017c4f1        2 minutes ago       394MB                 
```