### PR TITLE
Adding support for tracking Motherboard and BIOS firmware information

### DIFF
--- a/app/collins/models/AssetMeta.scala
+++ b/app/collins/models/AssetMeta.scala
@@ -206,15 +206,31 @@ object AssetMeta extends Schema with AnormAdapter[AssetMeta] with AssetMetaKeys 
     val BaseProduct = findOrCreateFromName("BASE_PRODUCT")
     val BaseVendor = findOrCreateFromName("BASE_VENDOR")
     val BaseSerial = findOrCreateFromName("BASE_SERIAL")
+    val BaseMotherboard = findOrCreateFromName("BASE_MOTHERBOARD")
+    val BaseFirmware = findOrCreateFromName("BASE_FIRMWARE")
     val GpuProduct= findOrCreateFromName("GPU_PRODUCT")
     val GpuVendor = findOrCreateFromName("GPU_VENDOR")
 
     def getValues(): Seq[AssetMeta] = {
-      Seq(BaseDescription, BaseProduct, BaseVendor, BaseSerial, GpuProduct, GpuVendor)
+      Seq(BaseDescription,
+          BaseProduct,
+          BaseVendor,
+          BaseSerial,
+          BaseMotherboard,
+          BaseFirmware,
+          GpuProduct,
+          GpuVendor)
     }
 
     def getLshwValues(): Set[AssetMeta] = {
-      Set(BaseDescription, BaseProduct, BaseVendor, BaseSerial, GpuProduct, GpuVendor)
+      Set(BaseDescription,
+          BaseProduct,
+          BaseVendor,
+          BaseSerial,
+          BaseMotherboard,
+          BaseFirmware,
+          GpuProduct,
+          GpuVendor)
     }
   }
 }

--- a/app/collins/models/AssetMeta.scala
+++ b/app/collins/models/AssetMeta.scala
@@ -208,6 +208,7 @@ object AssetMeta extends Schema with AnormAdapter[AssetMeta] with AssetMetaKeys 
     val BaseSerial = findOrCreateFromName("BASE_SERIAL")
     val BaseMotherboard = findOrCreateFromName("BASE_MOTHERBOARD")
     val BaseFirmware = findOrCreateFromName("BASE_FIRMWARE")
+    val BaseFirmwareDate = findOrCreateFromName("BASE_FIRMWAREDATE")
     val GpuProduct= findOrCreateFromName("GPU_PRODUCT")
     val GpuVendor = findOrCreateFromName("GPU_VENDOR")
 
@@ -218,6 +219,7 @@ object AssetMeta extends Schema with AnormAdapter[AssetMeta] with AssetMetaKeys 
           BaseSerial,
           BaseMotherboard,
           BaseFirmware,
+          BaseFirmwareDate,
           GpuProduct,
           GpuVendor)
     }
@@ -229,6 +231,7 @@ object AssetMeta extends Schema with AnormAdapter[AssetMeta] with AssetMetaKeys 
           BaseSerial,
           BaseMotherboard,
           BaseFirmware,
+          BaseFirmwareDate,
           GpuProduct,
           GpuVendor)
     }

--- a/app/collins/models/LshwHelper.scala
+++ b/app/collins/models/LshwHelper.scala
@@ -253,17 +253,19 @@ object LshwHelper extends CommonHelper[LshwRepresentation] {
 
   protected def reconstructBase(meta: Map[Int, Seq[MetaWrapper]]): FilteredSeq[ServerBase] = {
     val baseSeq = meta.get(0).map { seq =>
+      val baseMotherboard = amfinder(seq, BaseMotherboard, _.toString, "")
+      val baseFirmware = amfinder(seq, BaseFirmware, _.toString, "")
       val baseDescription = amfinder(seq, BaseDescription, _.toString, "")
       val baseProduct = amfinder(seq, BaseProduct, _.toString, "")
       val baseVendor = amfinder(seq, BaseVendor, _.toString, "")
       val baseSerial = amfinder(seq, BaseSerial, x => if (x.isEmpty) { None } else { Some(x) }, None)
-      Seq(ServerBase(baseDescription, baseProduct, baseVendor, baseSerial))
+      Seq(ServerBase(baseMotherboard, baseFirmware, baseDescription, baseProduct, baseVendor, baseSerial))
     }.getOrElse(Nil)
 
     val filteredMeta = meta.map { case(groupId, metaSeq) =>
       val newSeq = filterNot(
         metaSeq,
-        Set(BaseDescription.id, BaseProduct.id, BaseVendor.id, BaseSerial.id)
+        Set(BaseMotherboard.id, BaseFirmware.id, BaseDescription.id, BaseProduct.id, BaseVendor.id, BaseSerial.id)
       )
       groupId -> newSeq
     }
@@ -273,6 +275,8 @@ object LshwHelper extends CommonHelper[LshwRepresentation] {
   protected def collectBase(asset: Asset, lshw: LshwRepresentation): Seq[AssetMetaValue] = {
     val base = lshw.base
     val expectedAttrs = Seq(
+      AssetMetaValue(asset, BaseMotherboard.id, base.motherboard),
+      AssetMetaValue(asset, BaseFirmware.id, base.firmware),
       AssetMetaValue(asset, BaseDescription.id, base.description),
       AssetMetaValue(asset, BaseProduct.id, base.product),
       AssetMetaValue(asset, BaseVendor.id, base.vendor)

--- a/app/collins/models/LshwHelper.scala
+++ b/app/collins/models/LshwHelper.scala
@@ -253,19 +253,20 @@ object LshwHelper extends CommonHelper[LshwRepresentation] {
 
   protected def reconstructBase(meta: Map[Int, Seq[MetaWrapper]]): FilteredSeq[ServerBase] = {
     val baseSeq = meta.get(0).map { seq =>
-      val baseMotherboard = amfinder(seq, BaseMotherboard, _.toString, "")
-      val baseFirmware = amfinder(seq, BaseFirmware, _.toString, "")
+      val baseMotherboard = amfinder(seq, BaseMotherboard, x => if (x.isEmpty) { None } else { Some(x) }, None)
+      val baseFirmware= amfinder(seq, BaseFirmware, x => if (x.isEmpty) { None } else { Some(x) }, None)
+      val baseFirmwareDate= amfinder(seq, BaseFirmwareDate, x => if (x.isEmpty) { None } else { Some(x) }, None)
       val baseDescription = amfinder(seq, BaseDescription, _.toString, "")
       val baseProduct = amfinder(seq, BaseProduct, _.toString, "")
       val baseVendor = amfinder(seq, BaseVendor, _.toString, "")
       val baseSerial = amfinder(seq, BaseSerial, x => if (x.isEmpty) { None } else { Some(x) }, None)
-      Seq(ServerBase(baseMotherboard, baseFirmware, baseDescription, baseProduct, baseVendor, baseSerial))
+      Seq(ServerBase(baseMotherboard, baseFirmware, baseFirmwareDate, baseDescription, baseProduct, baseVendor, baseSerial))
     }.getOrElse(Nil)
 
     val filteredMeta = meta.map { case(groupId, metaSeq) =>
       val newSeq = filterNot(
         metaSeq,
-        Set(BaseMotherboard.id, BaseFirmware.id, BaseDescription.id, BaseProduct.id, BaseVendor.id, BaseSerial.id)
+        Set(BaseMotherboard.id, BaseFirmware.id, BaseFirmwareDate.id, BaseDescription.id, BaseProduct.id, BaseVendor.id, BaseSerial.id)
       )
       groupId -> newSeq
     }
@@ -275,8 +276,9 @@ object LshwHelper extends CommonHelper[LshwRepresentation] {
   protected def collectBase(asset: Asset, lshw: LshwRepresentation): Seq[AssetMetaValue] = {
     val base = lshw.base
     val expectedAttrs = Seq(
-      AssetMetaValue(asset, BaseMotherboard.id, base.motherboard),
-      AssetMetaValue(asset, BaseFirmware.id, base.firmware),
+      AssetMetaValue(asset, BaseMotherboard.id, base.motherboard.getOrElse("")),
+      AssetMetaValue(asset, BaseFirmware.id, base.firmware.getOrElse("")),
+      AssetMetaValue(asset, BaseFirmwareDate.id, base.firmwaredate.getOrElse("")),
       AssetMetaValue(asset, BaseDescription.id, base.description),
       AssetMetaValue(asset, BaseProduct.id, base.product),
       AssetMetaValue(asset, BaseVendor.id, base.vendor)

--- a/app/collins/models/lshw/ServerBase.scala
+++ b/app/collins/models/lshw/ServerBase.scala
@@ -9,11 +9,15 @@ import play.api.libs.json.Json
 object ServerBase {
   implicit object ServerbaseFormat extends Format[ServerBase] {
     override def reads(json: JsValue) = JsSuccess(ServerBase(
+      (json \ "MOTHERBOARD").as[String],
+      (json \ "FIRMWARE").as[String],
       (json \ "DESCRIPTION").as[String],
       (json \ "PRODUCT").as[String],
       (json \ "VENDOR").as[String],
       (json \ "SERIAL").asOpt[String]))
     override def writes(serverbase: ServerBase) = JsObject(Seq(
+      "MOTHERBOARD" -> Json.toJson(serverbase.motherboard),
+      "FIRMWARE" -> Json.toJson(serverbase.firmware),
       "DESCRIPTION" -> Json.toJson(serverbase.description),
       "PRODUCT" -> Json.toJson(serverbase.product),
       "VENDOR" -> Json.toJson(serverbase.vendor),
@@ -22,9 +26,9 @@ object ServerBase {
 }
 
 case class ServerBase(
-    description: String = "", product: String = "", vendor: String = "", serial: Option[String] = None) extends LshwAsset {
+    motherboard: String = "", firmware: String = "", description: String = "", product: String = "", vendor: String = "", serial: Option[String] = None) extends LshwAsset {
   import ServerBase._
   override def toJsValue() = Json.toJson(this)
 
-  def isEmpty(): Boolean = description.isEmpty && product.isEmpty && vendor.isEmpty && serial.isEmpty
+  def isEmpty(): Boolean = motherboard.isEmpty && firmware.isEmpty && description.isEmpty && product.isEmpty && vendor.isEmpty && serial.isEmpty
 }

--- a/app/collins/models/lshw/ServerBase.scala
+++ b/app/collins/models/lshw/ServerBase.scala
@@ -9,8 +9,9 @@ import play.api.libs.json.Json
 object ServerBase {
   implicit object ServerbaseFormat extends Format[ServerBase] {
     override def reads(json: JsValue) = JsSuccess(ServerBase(
-      (json \ "MOTHERBOARD").as[String],
-      (json \ "FIRMWARE").as[String],
+      (json \ "MOTHERBOARD").asOpt[String],
+      (json \ "FIRMWARE").asOpt[String],
+      (json \ "FIRMWAREDATE").asOpt[String],
       (json \ "DESCRIPTION").as[String],
       (json \ "PRODUCT").as[String],
       (json \ "VENDOR").as[String],
@@ -18,6 +19,7 @@ object ServerBase {
     override def writes(serverbase: ServerBase) = JsObject(Seq(
       "MOTHERBOARD" -> Json.toJson(serverbase.motherboard),
       "FIRMWARE" -> Json.toJson(serverbase.firmware),
+      "FIRMWAREDATE" -> Json.toJson(serverbase.firmwaredate),
       "DESCRIPTION" -> Json.toJson(serverbase.description),
       "PRODUCT" -> Json.toJson(serverbase.product),
       "VENDOR" -> Json.toJson(serverbase.vendor),
@@ -26,9 +28,9 @@ object ServerBase {
 }
 
 case class ServerBase(
-    motherboard: String = "", firmware: String = "", description: String = "", product: String = "", vendor: String = "", serial: Option[String] = None) extends LshwAsset {
+    motherboard: Option[String] = None, firmware: Option[String] = None, firmwaredate: Option[String] = None, description: String = "", product: String = "", vendor: String = "", serial: Option[String] = None) extends LshwAsset {
   import ServerBase._
   override def toJsValue() = Json.toJson(this)
 
-  def isEmpty(): Boolean = motherboard.isEmpty && firmware.isEmpty && description.isEmpty && product.isEmpty && vendor.isEmpty && serial.isEmpty
+  def isEmpty(): Boolean = motherboard.isEmpty && firmware.isEmpty && firmwaredate.isEmpty && description.isEmpty && product.isEmpty && vendor.isEmpty && serial.isEmpty
 }

--- a/app/collins/util/parsers/LshwParser.scala
+++ b/app/collins/util/parsers/LshwParser.scala
@@ -197,13 +197,29 @@ class LshwParser(txt: String) extends CommonParser[LshwRepresentation](txt) {
       val asset = getAsset(elem)
       // serial may be missing, so be flexible here and allow it to be absent
       val serial = (elem \ "serial" headOption).map(_.text)
-      ServerBase(asset.description, asset.product, asset.vendor, serial)
+      val motherboard = (elem \ "node" \ "product").headOption match {
+        case Some(x) => x.text
+        case None    => ""
+      }
+      val firmware = (elem \ "node" \ "node" \ "version").headOption match {
+        case Some(x) => x.text
+        case None    => ""
+      }
+      ServerBase(motherboard, firmware, asset.description, asset.product, asset.vendor, serial)
     } // To spice things up, sometimes we get <list>$everything</list>
     // instead of just $everything
     else if (((elem \ "node") \ "@class" text) == "system") {
       val asset = getAsset(elem \ "node")
       val serial = (elem \ "serial" headOption).map(_.text)
-      ServerBase(asset.description, asset.product, asset.vendor, serial)
+      val motherboard = (elem \ "node" \ "node" \ "product").headOption match {
+        case Some(x) => x.text
+        case None    => ""
+      }
+      val firmware = (elem \ "node" \ "node" \ "node" \ "version").headOption match {
+        case Some(x) => x.text
+        case None    => ""
+      }
+      ServerBase(motherboard, firmware, asset.description, asset.product, asset.vendor, serial)
     } else {
       throw MalformedAttributeException("Expected root class=system node attribute")
     }

--- a/app/collins/util/parsers/LshwParser.scala
+++ b/app/collins/util/parsers/LshwParser.scala
@@ -197,29 +197,19 @@ class LshwParser(txt: String) extends CommonParser[LshwRepresentation](txt) {
       val asset = getAsset(elem)
       // serial may be missing, so be flexible here and allow it to be absent
       val serial = (elem \ "serial" headOption).map(_.text)
-      val motherboard = (elem \ "node" \ "product").headOption match {
-        case Some(x) => x.text
-        case None    => ""
-      }
-      val firmware = (elem \ "node" \ "node" \ "version").headOption match {
-        case Some(x) => x.text
-        case None    => ""
-      }
-      ServerBase(motherboard, firmware, asset.description, asset.product, asset.vendor, serial)
+      val motherboard = (elem \ "node" \ "product" headOption).map(_.text)
+      val firmware = (elem \ "node" \ "node" \ "version" headOption).map(_.text)
+      val firmwaredate = (elem \ "node" \ "node" \ "date" headOption).map(_.text)
+      ServerBase(motherboard, firmware, firmwaredate, asset.description, asset.product, asset.vendor, serial)
     } // To spice things up, sometimes we get <list>$everything</list>
     // instead of just $everything
     else if (((elem \ "node") \ "@class" text) == "system") {
       val asset = getAsset(elem \ "node")
       val serial = (elem \ "serial" headOption).map(_.text)
-      val motherboard = (elem \ "node" \ "node" \ "product").headOption match {
-        case Some(x) => x.text
-        case None    => ""
-      }
-      val firmware = (elem \ "node" \ "node" \ "node" \ "version").headOption match {
-        case Some(x) => x.text
-        case None    => ""
-      }
-      ServerBase(motherboard, firmware, asset.description, asset.product, asset.vendor, serial)
+      val motherboard = (elem \ "node" \ "node" \ "product" headOption).map(_.text)
+      val firmware = (elem \ "node" \ "node" \ "node" \ "version" headOption).map(_.text)
+      val firmwaredate = (elem \ "node" \ "node" \ "node" \ "date" headOption).map(_.text)
+      ServerBase(motherboard, firmware, firmwaredate, asset.description, asset.product, asset.vendor, serial)
     } else {
       throw MalformedAttributeException("Expected root class=system node attribute")
     }

--- a/app/views/asset/show_hwdetails.scala.html
+++ b/app/views/asset/show_hwdetails.scala.html
@@ -26,9 +26,14 @@
         <tr>
           <td>Vendor</td><td>@aa.lshw.base.vendor</td>
         </tr>
-
         <tr>
             <td>Serial</td><td>@aa.lshw.base.serial</td>
+        </tr>
+        <tr>
+            <td>Motherboard</td><td>@aa.lshw.base.motherboard</td>
+        </tr>
+        <tr>
+            <td>Firmware</td><td>@aa.lshw.base.firmware</td>
         </tr>
       </tbody>
     </table>

--- a/app/views/asset/show_hwdetails.scala.html
+++ b/app/views/asset/show_hwdetails.scala.html
@@ -33,7 +33,10 @@
             <td>Motherboard</td><td>@aa.lshw.base.motherboard</td>
         </tr>
         <tr>
-            <td>Firmware</td><td>@aa.lshw.base.firmware</td>
+            <td>Motherboard Firmware</td><td>@aa.lshw.base.firmware</td>
+        </tr>
+        <tr>
+            <td>Firmware Date</td><td>@aa.lshw.base.firmwaredate</td>
         </tr>
       </tbody>
     </table>

--- a/conf/evolutions/collins/15.sql
+++ b/conf/evolutions/collins/15.sql
@@ -4,8 +4,10 @@
 
 INSERT INTO asset_meta (name, priority, label, description) VALUES ('BASE_MOTHERBOARD', -1, 'Base Motherboard', 'Motherboard product name');
 INSERT INTO asset_meta (name, priority, label, description) VALUES ('BASE_FIRMWARE', -1, 'Base Firmware', 'The motherboard firmware version');
+INSERT INTO asset_meta (name, priority, label, description) VALUES ('BASE_FIRMWAREDATE', -1, 'Base Firmware Date', 'The date the motherboard firmware was released');
 
 # --- !Downs
 
 DELETE FROM asset_meta WHERE name ='BASE_MOTHERBOARD'
 DELETE FROM asset_meta WHERE name ='BASE_FIRMWARE'
+DELETE FROM asset_meta WHERE name ='BASE_FIRMWAREDATE'

--- a/conf/evolutions/collins/15.sql
+++ b/conf/evolutions/collins/15.sql
@@ -1,4 +1,4 @@
-# --- Add GPU information to asset_meta
+# --- Add System motherboard, firmware and firmware release date to asset_meta
 
 # --- !Ups
 

--- a/conf/evolutions/collins/15.sql
+++ b/conf/evolutions/collins/15.sql
@@ -1,0 +1,11 @@
+# --- Add GPU information to asset_meta
+
+# --- !Ups
+
+INSERT INTO asset_meta (name, priority, label, description) VALUES ('BASE_MOTHERBOARD', -1, 'Base Motherboard', 'Motherboard product name');
+INSERT INTO asset_meta (name, priority, label, description) VALUES ('BASE_FIRMWARE', -1, 'Base Firmware', 'The motherboard firmware version');
+
+# --- !Downs
+
+DELETE FROM asset_meta WHERE name ='BASE_MOTHERBOARD'
+DELETE FROM asset_meta WHERE name ='BASE_FIRMWARE'

--- a/test/collins/util/parsers/LshwParserSpec.scala
+++ b/test/collins/util/parsers/LshwParserSpec.scala
@@ -550,8 +550,9 @@ class LshwParserSpec extends mutable.Specification {
         val parseResults = parsed()
         parseResults must beRight
         parseResults.right.toOption must beSome.which { rep =>
-          rep.base.motherboard mustEqual "0M91XC"
-          rep.base.firmware mustEqual "1.9.5"
+          rep.base.motherboard.get mustEqual "0M91XC"
+          rep.base.firmware.get mustEqual "1.9.5"
+          rep.base.firmwaredate.get mustEqual "12/22/2016"
         }
       }
 
@@ -559,8 +560,9 @@ class LshwParserSpec extends mutable.Specification {
         val parseResults = parsed()
         parseResults must beRight
         parseResults.right.toOption must beSome.which { rep =>
-          rep.base.motherboard mustEqual "X8DTN"
-          rep.base.firmware mustEqual "080016"
+          rep.base.motherboard.get mustEqual "X8DTN"
+          rep.base.firmware.get mustEqual "080016"
+          rep.base.firmwaredate.get mustEqual "03/17/2011"
         }
       }
 
@@ -568,17 +570,19 @@ class LshwParserSpec extends mutable.Specification {
         val parseResults = parsed()
         parseResults must beRight
         parseResults.right.toOption must beSome.which { rep =>
-          rep.base.motherboard mustEqual "001V46"
-          rep.base.firmware mustEqual "1.7.6"
+          rep.base.motherboard.get mustEqual "001V46"
+          rep.base.firmware.get mustEqual "1.7.6"
+          rep.base.firmwaredate.get mustEqual "04/21/2011"
         }
       }
 
-      "from a HP server that doesn't haven a motherboard version" in new LshwParserHelper("lshw-amd-opteron-wonky.xml") {
+      "from a HP server that doesn't have a motherboard version" in new LshwParserHelper("lshw-amd-opteron-wonky.xml") {
         val parseResults = parsed()
         parseResults must beRight
         parseResults.right.toOption must beSome.which { rep =>
-          rep.base.motherboard mustEqual ""
-          rep.base.firmware mustEqual "A24 (02/04/2011)"
+          rep.base.motherboard must beNone
+          rep.base.firmware.get mustEqual "A24 (02/04/2011)"
+          rep.base.firmwaredate must beNone
         }
       }
     }

--- a/test/collins/util/parsers/LshwParserSpec.scala
+++ b/test/collins/util/parsers/LshwParserSpec.scala
@@ -544,6 +544,43 @@ class LshwParserSpec extends mutable.Specification {
         }
       }
     }
-       
+
+    "Identify Motherboard and Firmware info" in {
+      "from a Dell workstation" in new LshwParserHelper("lshw-dell.xml") {
+        val parseResults = parsed()
+        parseResults must beRight
+        parseResults.right.toOption must beSome.which { rep =>
+          rep.base.motherboard mustEqual "0M91XC"
+          rep.base.firmware mustEqual "1.9.5"
+        }
+      }
+
+      "from a Supermicro server" in new LshwParserHelper("lshw-intel.xml") {
+        val parseResults = parsed()
+        parseResults must beRight
+        parseResults.right.toOption must beSome.which { rep =>
+          rep.base.motherboard mustEqual "X8DTN"
+          rep.base.firmware mustEqual "080016"
+        }
+      }
+
+      "from the dynamic enum server lshw" in new LshwParserHelper("lshw-basic-dynamic-enums.xml") {
+        val parseResults = parsed()
+        parseResults must beRight
+        parseResults.right.toOption must beSome.which { rep =>
+          rep.base.motherboard mustEqual "001V46"
+          rep.base.firmware mustEqual "1.7.6"
+        }
+      }
+
+      "from a HP server that doesn't haven a motherboard version" in new LshwParserHelper("lshw-amd-opteron-wonky.xml") {
+        val parseResults = parsed()
+        parseResults must beRight
+        parseResults.right.toOption must beSome.which { rep =>
+          rep.base.motherboard mustEqual ""
+          rep.base.firmware mustEqual "A24 (02/04/2011)"
+        }
+      }
+    }
   } // The LSHW parser should
 }


### PR DESCRIPTION
I'm open to suggestions on the best way to track this information, but here is an initial stab.

Screenshot of the updated Server Base hardware details view:

![image](https://user-images.githubusercontent.com/5204426/30436933-5ae58ea0-993b-11e7-9009-dcecf8f21b75.png)


I added four tests to validate the motherboard/BIOS info is correct. Let me know if there are any other edge cases that would be appropriate.

(For some background our hardware teams are going to start using this information and we'd like to get it into collins.)

Fixes tumblr/collins#555

cc @michaeljs1990 @byxorna 