### PR TITLE
CSRF protection for web forms

### DIFF
--- a/app/views/login.scala.html
+++ b/app/views/login.scala.html
@@ -53,6 +53,7 @@
           @loginForm("location").value.map { value =>
           <input type="hidden" name="location" value="@value">
           }
+          @helper.CSRF.formField
         }
       </div>
     </div>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -89,6 +89,7 @@
             <input class="input-medium form-control" type="text" name="username" placeholder="Username">
             <input class="input-medium form-control" type="password" name="password" placeholder="Password">
             <button class="btn btn-default" type="submit">Sign in</button>
+	    @helper.CSRF.formField
           </form>
         </div>
       </div>

--- a/app/views/resources/create.scala.html
+++ b/app/views/resources/create.scala.html
@@ -54,6 +54,7 @@
               <button type="submit" class="btn btn-primary">Create @atype.label</button>
             </div>
           </div>
+          @helper.CSRF.formField
         </form>
       </div>
     </div>

--- a/build.sbt
+++ b/build.sbt
@@ -56,4 +56,4 @@ libraryDependencies ++= Seq(
   "org.webjars" % "jquery" % "2.1.4",
   "com.hazelcast" % "hazelcast" % "3.5.2",
   ws
-)
+) :+ filters

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers ++= Seq(
     "Sontype Releases" at "https://oss.sonatype.org/content/repositories/releases/"
 )
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.3.9"))
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.3.10"))
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
 


### PR DESCRIPTION
This adds protection from CSRF attacks by adding a token check to non-API endpoints. Currently, if an attacker can guess (or bruteforce) the asset tags of nodes he or she would be able to create assets, decommission assets, put assets in maintenance, etc. by getting a logged in user to visit a webpage. Depending on the type of automation and asset tags in the installation this could obviously be very bad.

This only applies to routes using session authentication and not the API since it is protected by basic authentication. Furthermore, only the login and create resource forms actually have the CSRF token in a hidden input tag since the other forms submit their data through XHR.

We will post a nginx-based workaround on the mailing list, but recommend users to update collins as well. I will publish a new release (2.2.0) once this is merged.

@tumblr/collins 