### PR TITLE
Document onlyUnallocated parameter

### DIFF
--- a/_data/api.yml
+++ b/_data/api.yml
@@ -677,6 +677,9 @@ sections:
           tag:
             type: String
             description: Must be alphanumeric (but can include underscores and dashes) and unique
+          onlyUnallocated:
+            type: Option[Boolean]
+            description: If true, return only assets that are in unallocated state. Defaults to true.
         response_codes:
           200: Zero or more assets successfully found
         examples:


### PR DESCRIPTION
This parameter is used by the web UI and the ruby client but isn't in the documentation. This just adds a quick sentence about it and what it does.

@tumblr/collins 