### PR TITLE
Remove Versioneye badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ For documentation on developing, building, general architecture and unreleased c
 All documentation links point to the most recent release.
 
 [![Build Status](https://travis-ci.org/tumblr/collins.png?branch=master)](https://travis-ci.org/tumblr/collins)
-[![Dependency Status](https://www.versioneye.com/user/projects/555e7598393564000d040000/badge.svg?style=flat)](https://www.versioneye.com/user/projects/555e7598393564000d040000)
 
 ## Quickstart
 


### PR DESCRIPTION
The key used for running Versioneye on Collins was @maddalab's and is no longer valid since he isn't working on Collins anymore. We could set up a new "proper" versioneye account, but it's shutting down [1] so it's probably not worth the effort.

This sort-of-but-not-really addresses #574. If anyone has suggestions for similar services I'd love to explore the options.

[1] https://blog.versioneye.com/2017/10/19/versioneye-sunset-process/

@tumblr/collins 