### PR TITLE
Update the thor dependency constraint for collins-shell

### DIFF
--- a/support/ruby/collins-shell/Gemfile.lock
+++ b/support/ruby/collins-shell/Gemfile.lock
@@ -2,12 +2,12 @@ PATH
   remote: .
   specs:
     collins_shell (0.2.24)
-      collins_client (~> 0.2.11)
+      collins_client (~> 0.2.20)
       highline (~> 1.6.15)
       mustache (~> 0.99.4)
       pry (~> 0.9.9.6)
       terminal-table (~> 1.4.5)
-      thor (~> 0.16.0)
+      thor (~> 0.19.0)
 
 GEM
   remote: http://rubygems.org/
@@ -19,7 +19,7 @@ GEM
       net-ssh (>= 2.0.14)
       net-ssh-gateway (>= 1.1.0)
     coderay (1.0.9)
-    collins_client (0.2.19)
+    collins_client (0.2.21)
       httparty (~> 0.11.0)
     diff-lcs (1.1.3)
     highline (1.6.21)
@@ -27,7 +27,7 @@ GEM
       multi_json (~> 1.0)
       multi_xml (>= 0.5.2)
     method_source (0.7.1)
-    multi_json (1.12.1)
+    multi_json (1.13.1)
     multi_xml (0.6.0)
     mustache (0.99.8)
     net-scp (1.2.1)
@@ -52,7 +52,7 @@ GEM
     rspec-mocks (2.10.1)
     slop (2.4.4)
     terminal-table (1.4.5)
-    thor (0.16.0)
+    thor (0.19.4)
     yard (0.8.3)
 
 PLATFORMS
@@ -66,4 +66,4 @@ DEPENDENCIES
   yard (~> 0.8)
 
 BUNDLED WITH
-   1.13.6
+   1.16.1

--- a/support/ruby/collins-shell/collins_shell.gemspec
+++ b/support/ruby/collins-shell/collins_shell.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('mustache','~> 0.99.4')
   s.add_runtime_dependency('pry','~> 0.9.9.6')
   s.add_runtime_dependency('terminal-table','~> 1.4.5')
-  s.add_runtime_dependency('thor','~> 0.16.0')
+  s.add_runtime_dependency('thor','~> 0.19.0')
 
   s.add_development_dependency('rspec','~> 2.10.0')
   s.add_development_dependency('redcarpet')


### PR DESCRIPTION
I need to install it alongside test-kitchen, which depends on <~ 0.19.0,
so do the same here.

We have been using this internally for a little while now and it works fine. I have not tested even newer thor versions.