### PR TITLE
Fix the ::Fixnum deprecation warning on Ruby 2.4+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ matrix:
     - jdk: oraclejdk7
       env: RUN_RUBY=true RUN_SCALA=false GEM_NAME=collins-client
     - jdk: oraclejdk7
+      env: RUN_RUBY=true RUN_SCALA=false GEM_NAME=collins-shell
+    - jdk: oraclejdk7
       env: RUN_RUBY=true RUN_SCALA=false GEM_NAME=collins-state
     - jdk: oraclejdk7
       env: RUN_RUBY=true RUN_SCALA=false GEM_NAME=consolr

--- a/support/ruby/collins-shell/.gitignore
+++ b/support/ruby/collins-shell/.gitignore
@@ -2,3 +2,4 @@
 *.gem
 doc/
 .yardoc
+.bundle/

--- a/support/ruby/collins-shell/Gemfile.lock
+++ b/support/ruby/collins-shell/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     collins_shell (0.2.24)
-      collins_client (~> 0.2.11)
+      collins_client (~> 0.2.20)
       highline (~> 1.6.15)
       mustache (~> 0.99.4)
       pry (~> 0.9.9.6)
@@ -12,6 +12,8 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
+    addressable (2.4.0)
+    builder (3.2.3)
     capistrano (2.15.9)
       highline
       net-scp (>= 1.0.0)
@@ -19,41 +21,88 @@ GEM
       net-ssh (>= 2.0.14)
       net-ssh-gateway (>= 1.1.0)
     coderay (1.0.9)
-    collins_client (0.2.19)
+    collins_client (0.2.21)
       httparty (~> 0.11.0)
-    diff-lcs (1.1.3)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
+    diff-lcs (1.3)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    git (1.3.0)
+    github_api (0.16.0)
+      addressable (~> 2.4.0)
+      descendants_tracker (~> 0.0.4)
+      faraday (~> 0.8, < 0.10)
+      hashie (>= 3.4)
+      mime-types (>= 1.16, < 3.0)
+      oauth2 (~> 1.0)
+    hashie (3.5.7)
     highline (1.6.21)
     httparty (0.11.0)
       multi_json (~> 1.0)
       multi_xml (>= 0.5.2)
+    jeweler (2.3.9)
+      builder
+      bundler
+      git (>= 1.2.5)
+      github_api (~> 0.16.0)
+      highline (>= 1.6.15)
+      nokogiri (>= 1.5.10)
+      psych
+      rake
+      rdoc
+      semver2
+    jwt (1.5.6)
     method_source (0.7.1)
-    multi_json (1.12.1)
+    mime-types (2.99.3)
+    mini_portile2 (2.3.0)
+    multi_json (1.13.1)
     multi_xml (0.6.0)
+    multipart-post (2.0.0)
     mustache (0.99.8)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
-    net-ssh (4.1.0)
+    net-ssh (4.2.0)
     net-ssh-gateway (2.0.0)
       net-ssh (>= 4.0.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
+    oauth2 (1.4.0)
+      faraday (>= 0.8, < 0.13)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
     pry (0.9.9.6)
       coderay (~> 1.0.5)
       method_source (~> 0.7.1)
       slop (>= 2.4.4, < 3)
-    redcarpet (2.2.2)
-    rspec (2.10.0)
-      rspec-core (~> 2.10.0)
-      rspec-expectations (~> 2.10.0)
-      rspec-mocks (~> 2.10.0)
-    rspec-core (2.10.1)
-    rspec-expectations (2.10.0)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.10.1)
+    psych (3.0.2)
+    rack (2.0.4)
+    rake (12.3.0)
+    rdoc (6.0.1)
+    redcarpet (3.4.0)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.1)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.1)
+    semver2 (3.4.2)
     slop (2.4.4)
     terminal-table (1.4.5)
     thor (0.16.0)
-    yard (0.8.3)
+    thread_safe (0.3.6)
+    yard (0.9.12)
 
 PLATFORMS
   ruby
@@ -61,9 +110,11 @@ PLATFORMS
 DEPENDENCIES
   capistrano (~> 2.15.5)
   collins_shell!
+  jeweler
+  rake
   redcarpet
-  rspec (~> 2.10.0)
+  rspec
   yard (~> 0.8)
 
 BUNDLED WITH
-   1.13.6
+   1.16.1

--- a/support/ruby/collins-shell/Rakefile
+++ b/support/ruby/collins-shell/Rakefile
@@ -55,10 +55,17 @@ task :all => ["version:bump:patch", :publish] do
   puts("Done!")
 end
 
-task :default => :yard
+require 'rspec/core'
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec) do |spec|
+  spec.fail_on_error = true
+  spec.pattern = FileList['spec/**/*_spec.rb']
+end
 
 require 'yard'
 YARD::Rake::YardocTask.new do |t|
   t.files = ['lib/**/*.rb']
   t.options = ['--markup', 'markdown']
 end
+
+task :default => [:yard, :spec]

--- a/support/ruby/collins-shell/collins_shell.gemspec
+++ b/support/ruby/collins-shell/collins_shell.gemspec
@@ -63,8 +63,10 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('terminal-table','~> 1.4.5')
   s.add_runtime_dependency('thor','~> 0.16.0')
 
-  s.add_development_dependency('rspec','~> 2.10.0')
+  s.add_development_dependency('rspec')
   s.add_development_dependency('redcarpet')
   s.add_development_dependency('yard','~> 0.8')
   s.add_development_dependency('capistrano','~> 2.15.5')
+  s.add_development_dependency('rake')
+  s.add_development_dependency('jeweler')
 end

--- a/support/ruby/collins-shell/lib/collins_shell/monkeypatch.rb
+++ b/support/ruby/collins-shell/lib/collins_shell/monkeypatch.rb
@@ -15,7 +15,7 @@ class Float
   end
 end
 
-class Fixnum
+class Integer
 
   def to_human_size
     return "0 Bytes" if (self == 0)

--- a/support/ruby/collins-shell/spec/monkeypatch_spec.rb
+++ b/support/ruby/collins-shell/spec/monkeypatch_spec.rb
@@ -1,0 +1,58 @@
+require 'rspec'
+require_relative '../lib/collins_shell/monkeypatch'
+
+describe Float do
+  describe '#to_human_size' do
+    {
+      0.0 => '0 Bytes',
+      -0.0 => '0 Bytes',
+      # FIXME: floating point precision problems here
+      Float::EPSILON => '256.00000000000000 Bytes',
+      1.2 => '1.2 Bytes',
+      12.3 => '12.3 Bytes',
+      123.4 => '123.4 Bytes',
+      1234.5 => '1.20556640625000 KB',
+      12345.6 => '12.05625000000000 KB',
+      123456.7 => '120.56318359375000 KB',
+      1234567.8 => '1.17737560272217 MB',
+      12345678.9 => '11.77375688552856 MB',
+      123456789.0 => '117.73756885528564 MB',
+      1234567890.1 => '1.14978094594553 GB',
+      12345678901.2 => '11.49780945964158 GB',
+      123456789012.3 => '114.97809459669516 GB',
+      1234567890123.4 => '1.12283295504621 TB',
+      12345678901234.5 => '11.22832955046260 TB',
+      123456789012345.6 => '112.28329550462658 TB',
+      1234567890123456.7 => '1.09651655766237 PB',
+      12345678901234567.8 => '10.96516557662370 PB',
+      123456789012345678.9 => '109.65165576623697 PB',
+    }.each do |from, want|
+      it "converts #{from} to #{want}" do
+        expect(from.to_human_size).to eql(want)
+      end
+    end
+  end
+end
+
+describe Fixnum do
+  describe '#to_human_size' do
+    {
+      0 => '0 Bytes',
+      1 => '1 Bytes',
+      12 => '12 Bytes',
+      123 => '123 Bytes',
+      1234 => '1.00 KB',
+      12345 => '12.00 KB',
+      123456 => '120.00 KB',
+      1234567 => '1.00 MB',
+      12345678 => '11.00 MB',
+      123456789 => '117.00 MB',
+      1234567890 => '1.00 GB',
+      12345678901 => '11.00 GB',
+    }.each do |from, want|
+      it "converts #{from} to #{want}" do
+        expect(from.to_human_size).to eql(want)
+      end
+    end
+  end
+end

--- a/support/ruby/collins-shell/spec/monkeypatch_spec.rb
+++ b/support/ruby/collins-shell/spec/monkeypatch_spec.rb
@@ -34,7 +34,7 @@ describe Float do
   end
 end
 
-describe Fixnum do
+describe Integer do
   describe '#to_human_size' do
     {
       0 => '0 Bytes',


### PR DESCRIPTION
Fixnum has been [replaced](https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released/) by Integer (which used to be a parent class), triggering a very noisy warning.

It is actually safe to add the `to_human_size` method to Integer even on older Ruby version, so this change does that. To get confidence in this I needed to add some tests, so I needed to set up testing for collins-shell in the first place, which in turn required some Gem fixes.