### PR TITLE
Multistage docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=dev /build /build
 
 # Copy source and build package
 COPY . /build/collins
-RUN PLAY_CMD=/build/activator-${activator_version}-minimal/activator FORCE_BUILD=true ./scripts/package.sh
+RUN PLAY_CMD=/build/activator-${activator_version}-minimal/activator ./scripts/package.sh
 
 # Production stage with just the build artifacts and configs
 FROM openjdk:8-jre AS production

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -18,10 +18,11 @@ if [ ! -f $PLAY_CMD ]; then
   exit 1
 fi
 
-java_version=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')
+# Extract java major version (e.g. 8 for 1.8.0)
+java_version=$(java -version 2>&1 | head -1 | sed -E 's/.*1\.([0-9]+).0.*/\1/')
 echo "Building using java version $java_version"
-if [[ ! "$java_version" =~ "1.7" ]] && [[ ! $FORCE_BUILD == "true" ]]; then
-    echo "Collins should only be built with java version 1.7.  If you really know what you are doing, set the FORCE_BUILD enviornment variable to 'true'"
+if [[ "$java_version" > "8" ]] && [[ ! $FORCE_BUILD == "true" ]]; then
+    echo "Collins has not been tested with java versions newer than 8.  If you still want to build with this version, set the FORCE_BUILD enviornment variable to 'true'"
     exit 1
 fi
 


### PR DESCRIPTION
This adds a multistage dockerfile based on @byxorna 's work in #562. The main difference is that this one actually has three stages. `dev`, ` build`, and `production`. The reason for the addition of the first stage is to make it easy to set up the development environment and start hacking. By targeting that stage we can build and start the dev environment easily:
```
$  docker build --target dev -t collins-dev .
$  docker run -v "$(pwd)":/build/collins -it collins-dev
```
This will launch into activator where we then can start watching for changes and rebuild whenever a file on the local copy changes:
```
[collins] $ ~compile
[success] Total time: 0 s, completed Feb 1, 2019 2:30:02 AM
1. Waiting for source changes... (press enter to interrupt)
[success] Total time: 0 s, completed Feb 1, 2019 2:30:17 AM
2. Waiting for source changes... (press enter to interrupt)
[success] Total time: 0 s, completed Feb 1, 2019 2:30:25 AM
3. Waiting for source changes... (press enter to interrupt)
[info] Compiling 1 Scala source to /build/collins/target/scala-2.11/classes...
[success] Total time: 2 s, completed Feb 1, 2019 2:30:31 AM
```

I'm also updating the java version gating in `scripts/package.sh` to check for java newer than 1.8, and have it print a warning message if it is.

@tumblr/collins @byxorna 