### PR TITLE
python collins_clients -> python3; v1.0.0

### DIFF
--- a/support/python/collins_client/setup.py
+++ b/support/python/collins_client/setup.py
@@ -3,9 +3,9 @@
 from setuptools import setup, find_packages
 
 setup(name="collins_client",
-      version="0.1.1",
+      version="1.0.0",
       description="The python interface to the collins api.",
-      author="John Bunting, Nick Thuesen, Nick Sauro, Will Richard, John Hogenmiller",
+      author="Tumblr Inc.",
       author_email="opensourcesoftware@tumblr.com",
       url="https://github.com/tumblr/collins/tree/master/support/python/collins_client",
       packages=find_packages(),
@@ -15,9 +15,9 @@ setup(name="collins_client",
           'Intended Audience :: Developers',
           'Intended Audience :: System Administrators',
           'License :: OSI Approved :: Apache Software License',
-          'Programming Language :: Python :: 2 :: Only',
-          'Programming Language :: Python :: 2.6',
-          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3 :: Only',
+          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
           'Topic :: System :: Systems Administration'
       ],
       install_requires= [


### PR DESCRIPTION
what
---
updates collins_client to python 3 ^_^ tested with python 3.6 and 3.7

test results
---
confirmed our [readme example](https://github.com/dkarivalis/collins/tree/master/support/python/collins_client) still produces valid requests:

python 2.7 with collins_client=0.1.1:
```
➜  ~ nc -l 8080
GET /api/assets?attribute=HOSTNAME%3Bexample.tumblr.net&attribute=PRIMARY_ROLE%3BTUMBLR_APP HTTP/1.1
Accept-Encoding: identity
Host: 127.0.0.1:8080
Connection: close
Authorization: Basic ZGF2ZTp0ZXN0
User-Agent: Python-urllib/2.7
```

python 3.6 with collins_client=1.0.0:
```
➜  ~ nc -l 8080
GET /api/assets?attribute=HOSTNAME%3Bexample.tumblr.net&attribute=PRIMARY_ROLE%3BTUMBLR_APP HTTP/1.1
Accept-Encoding: identity
Host: 127.0.0.1:8080
User-Agent: Python-urllib/3.6
Authorization: Basic ZGF2ZTp0ZXN0
Connection: close
```

python 3.7 with collins_client=1.0.0:
```
➜  ~ nc -l 8080
GET /api/assets?attribute=HOSTNAME%3Bexample.tumblr.net&attribute=PRIMARY_ROLE%3BTUMBLR_APP HTTP/1.1
Accept-Encoding: identity
Host: 127.0.0.1:8080
User-Agent: Python-urllib/3.7
Authorization: Basic ZGF2ZTp0ZXN0
Connection: close
```

@tumblr/collins @defect @komapa 