### PR TITLE
Extract and store logical disk name from lshw data

### DIFF
--- a/app/collins/models/AssetMeta.scala
+++ b/app/collins/models/AssetMeta.scala
@@ -211,6 +211,7 @@ object AssetMeta extends Schema with AnormAdapter[AssetMeta] with AssetMetaKeys 
     val BaseFirmwareDate = findOrCreateFromName("BASE_FIRMWAREDATE")
     val GpuProduct= findOrCreateFromName("GPU_PRODUCT")
     val GpuVendor = findOrCreateFromName("GPU_VENDOR")
+    val DiskLogicalName = findOrCreateFromName("DISK_LOGICAL_NAME")
 
     def getValues(): Seq[AssetMeta] = {
       Seq(BaseDescription,
@@ -221,7 +222,8 @@ object AssetMeta extends Schema with AnormAdapter[AssetMeta] with AssetMetaKeys 
           BaseFirmware,
           BaseFirmwareDate,
           GpuProduct,
-          GpuVendor)
+          GpuVendor,
+          DiskLogicalName)
     }
 
     def getLshwValues(): Set[AssetMeta] = {
@@ -233,7 +235,8 @@ object AssetMeta extends Schema with AnormAdapter[AssetMeta] with AssetMetaKeys 
           BaseFirmware,
           BaseFirmwareDate,
           GpuProduct,
-          GpuVendor)
+          GpuVendor,
+          DiskLogicalName)
     }
   }
 }

--- a/app/collins/models/LshwHelper.scala
+++ b/app/collins/models/LshwHelper.scala
@@ -218,17 +218,18 @@ object LshwHelper extends CommonHelper[LshwRepresentation] {
       val diskSize = finder(wrapSeq, DiskSizeBytes, _.toLong, 0L)
       val diskType = finder(wrapSeq, DiskType, {s => Some(Disk.Type.withName(s))}, None)
       val descr = finder(wrapSeq, DiskDescription, _.toString, "")
+      val logicalName = amfinder(wrapSeq, DiskLogicalName, _.toString, "")
       if (diskSize == 0L && diskType.isEmpty && descr.isEmpty) {
         seq
       } else {
         val size = ByteStorageUnit(diskSize)
-        Disk(size, diskType.get, descr, "", "") +: seq
+        Disk(size, diskType.get, descr, "", "", logicalName) +: seq
       }
     }
     val filteredMeta = meta.map { case(groupId, metaSeq) =>
       val newSeq = filterNot(
         metaSeq,
-        Set(DiskSizeBytes.id, DiskType.id, DiskDescription.id)
+        Set(DiskSizeBytes.id, DiskType.id, DiskDescription.id, DiskLogicalName.id)
       )
       groupId -> newSeq
     }
@@ -244,7 +245,8 @@ object LshwHelper extends CommonHelper[LshwRepresentation] {
       (groupId + 1, total ++ Seq(
         AssetMetaValue(asset, DiskSizeBytes.id, groupId, disk.size.inBytes.toString),
         AssetMetaValue(asset, DiskType.id, groupId, disk.diskType.toString),
-        AssetMetaValue(asset, DiskDescription.id, groupId, "%s %s".format(disk.vendor, disk.product))
+        AssetMetaValue(asset, DiskDescription.id, groupId, "%s %s".format(disk.vendor, disk.product)),
+        AssetMetaValue(asset, DiskLogicalName.id, groupId, disk.logicalname)
       ))
     }._2
     val diskSummary = AssetMetaValue(asset, DiskStorageTotal.id, lshw.totalUsableStorage.inBytes.toString)

--- a/app/collins/models/lshw/Disk.scala
+++ b/app/collins/models/lshw/Disk.scala
@@ -24,7 +24,8 @@ object Disk {
       Disk.Type.withName((json \ "TYPE").as[String]),
       (json \ "DESCRIPTION").as[String],
       (json \ "PRODUCT").as[String],
-      (json \ "VENDOR").as[String]))
+      (json \ "VENDOR").as[String],
+      (json \ "LOGICALNAME").as[String]))
     override def writes(disk: Disk) = JsObject(Seq(
       "SIZE" -> Json.toJson(disk.size.inBytes),
       "SIZE_S" -> Json.toJson(disk.size.inBytes.toString),
@@ -32,12 +33,13 @@ object Disk {
       "TYPE" -> Json.toJson(disk.diskType.toString),
       "DESCRIPTION" -> Json.toJson(disk.description),
       "PRODUCT" -> Json.toJson(disk.product),
-      "VENDOR" -> Json.toJson(disk.vendor)))
+      "VENDOR" -> Json.toJson(disk.vendor),
+      "LOGICALNAME" -> Json.toJson(disk.logicalname)))
   }
 }
 
 case class Disk(
-    size: ByteStorageUnit, diskType: Disk.Type, description: String, product: String, vendor: String) extends LshwAsset {
+    size: ByteStorageUnit, diskType: Disk.Type, description: String, product: String, vendor: String, logicalname: String) extends LshwAsset {
 
   import Disk._
 

--- a/app/collins/util/parsers/LshwParser.scala
+++ b/app/collins/util/parsers/LshwParser.scala
@@ -118,11 +118,13 @@ class LshwParser(txt: String) extends CommonParser[LshwRepresentation](txt) {
         case noSize if noSize.isEmpty => ByteStorageUnit(0)
         case size                     => ByteStorageUnit(size.toLong)
       }
-      Disk(size, _type, asset.description, asset.product, asset.vendor)
+      val logicalname = (n \ "logicalname" text)
+      Disk(size, _type, asset.description, asset.product, asset.vendor, logicalname)
     case n if ((n \ "@class" text) == "memory" || (n \ "@class" text) == "storage") && LshwConfig.flashProducts.exists(s => (n \ "product" text).toLowerCase.contains(s)) =>
       val asset = getAsset(n)
       val size = ByteStorageUnit(LshwConfig.flashSize)
-      Disk(size, Disk.Type.Flash, asset.description, asset.product, asset.vendor)
+      val logicalname = (n \ "logicalname" text)
+      Disk(size, Disk.Type.Flash, asset.description, asset.product, asset.vendor, logicalname)
   }
 
   private val defaultNicCapacity = LshwConfig.defaultNicCapacity

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ resolvers += "Twitter Repository" at "http://maven.twttr.com/"
 
 resolvers += "Sonatype-public" at "http://oss.sonatype.org/content/groups/public"
 
-resolvers += "Restlet repository" at "http://maven.restlet.org"
+resolvers += "Restlet repository" at "https://maven.restlet.talend.com"
 
 Keys.fork in Test := true
 

--- a/conf/evolutions/collins/16.sql
+++ b/conf/evolutions/collins/16.sql
@@ -1,0 +1,9 @@
+# --- Add logical name of disks to asset meta
+
+# --- !Ups
+
+INSERT INTO asset_meta (name, priority, label, description) VALUES ('DISK_LOGICAL_NAME', -1, 'Disk logical name', 'The logical name of the disk as reported by lshw');
+
+# --- !Downs
+
+DELETE FROM asset_meta WHERE name ='DISK_LOGICAL_NAME'


### PR DESCRIPTION
This makes the LSHW parser and hw models grab the `logicalname` (i.e. `/dev/sda`, `/dev/sdb` and so on) of each disk from the lshw output. 

This is because lshw doesn't always report them in order, and collins doesn't do a very good job at returning them in order. This makes it tricky to automate things without making a lot of assumptions, and we've had some hardware break those assumptions recently :) Having the logical name attached to each disk should help with automating the disk setup.

If lshw doesn't have the `logicalname` key for some reason it'lll just be an empty string.

I'm also updating the URL to the restlet repo which has apparently moved.

@tumblr/collins 