### PR TITLE
Fix build by updating repo URLs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM openjdk:8-jdk AS dev
 ARG activator_version
 WORKDIR /build
 # install prereqs
-RUN wget -q http://downloads.typesafe.com/typesafe-activator/${activator_version}/typesafe-activator-${activator_version}-minimal.zip -O /build/activator.zip && \
+RUN wget -q https://downloads.typesafe.com/typesafe-activator/${activator_version}/typesafe-activator-${activator_version}-minimal.zip -O /build/activator.zip && \
     unzip -q ./activator.zip
 
 WORKDIR /build/collins

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
-resolvers += "Twitter Repository" at "http://maven.twttr.com/"
+resolvers += "Twitter Repository" at "https://maven.twttr.com/"
 
-resolvers += "Sonatype-public" at "http://oss.sonatype.org/content/groups/public"
+resolvers += "Sonatype-public" at "https://oss.sonatype.org/content/groups/public"
 
 resolvers += "Restlet repository" at "https://maven.restlet.talend.com"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.15

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers ++= Seq(
     DefaultMavenRepository,
-    Resolver.url("Play", url("http://download.playframework.org/ivy-releases/"))(Resolver.ivyStylePatterns),
-    "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/",
+    Resolver.url("Play", url("https://downloads.lightbend.com/ivy-releases/"))(Resolver.ivyStylePatterns),
+    "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/",
     "Sontype Releases" at "https://oss.sonatype.org/content/repositories/releases/"
 )
 


### PR DESCRIPTION
Some of the 3rd party repos we use now require https. This updates those to use https, and also updates sbt to 0.13.15 which defaults to https for some key repos.

@tumblr/collins 